### PR TITLE
Small fixes for issues found when running against our codebase

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 	"os"
 )
 
-
-
 var (
 	doWrite = flag.Bool("w", false, "doWrite result to (source) file instead of stdout")
 	doDiff  = flag.Bool("d", false, "display diffs instead of rewriting files")
@@ -20,6 +18,9 @@ var (
 )
 
 func report(err error) {
+	if err == nil {
+		return
+	}
 	scanner.PrintError(os.Stderr, err)
 	exitCode = 1
 }
@@ -36,7 +37,6 @@ func usage() {
 	flag.PrintDefaults()
 	os.Exit(2)
 }
-
 
 func main() {
 	flag.Usage = usage

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -143,9 +143,9 @@ func getPkgInfo(line string, comment bool) (string, string, string) {
 		s := strings.Split(line, commentFlag)
 		pkgArray := strings.Split(s[0], blank)
 		if len(pkgArray) > 1 {
-			return pkgArray[1], pkgArray[0], fmt.Sprintf("%s%s%s", commentFlag, blank, s[1])
+			return pkgArray[1], pkgArray[0], fmt.Sprintf("%s%s%s", commentFlag, blank, strings.TrimSpace(s[1]))
 		} else {
-			return pkgArray[0], "", fmt.Sprintf("%s%s%s", commentFlag, blank, s[1])
+			return pkgArray[0], "", fmt.Sprintf("%s%s%s", commentFlag, blank, strings.TrimSpace(s[1]))
 		}
 	} else {
 		pkgArray := strings.Split(line, blank)

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -127,7 +127,7 @@ func (p *pkg) fmt() []byte {
 			ret = append(ret, linebreak)
 		}
 	}
-	if ret[len(ret)-1] == linebreak {
+	if len(ret) > 0 && ret[len(ret)-1] == linebreak {
 		ret = ret[:len(ret)-1]
 	}
 
@@ -351,6 +351,11 @@ func Run(filename string, set *FlagSet) ([]byte, []byte, error) {
 		return nil, nil, nil
 	}
 	end := bytes.Index(src[start:], importEndFlag) + start
+	
+	// in case import flags are part of a codegen template, or otherwise "wrong"
+	if start+len(importStartFlag) > end {
+		return nil, nil
+	}
 
 	ret := bytes.Split(src[start+len(importStartFlag):end], []byte(linebreak))
 

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -328,18 +328,19 @@ func processFile(filename string, out io.Writer, set *FlagSet) error {
 	return err
 }
 
-func Run(filename string, set *FlagSet) ([]byte, error) {
+// Run return source and result in []byte if succeed
+func Run(filename string, set *FlagSet) ([]byte, []byte, error) {
 	var err error
 
 	f, err := os.Open(filename)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer f.Close()
 
 	src, err := ioutil.ReadAll(f)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ori := make([]byte, len(src))
@@ -347,7 +348,7 @@ func Run(filename string, set *FlagSet) ([]byte, error) {
 	start := bytes.Index(src, importStartFlag)
 	// in case no importStartFlag or importStartFlag exist in the commentFlag
 	if start < 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	end := bytes.Index(src[start:], importEndFlag) + start
 
@@ -358,13 +359,8 @@ func Run(filename string, set *FlagSet) ([]byte, error) {
 	res := append(src[:start+len(importStartFlag)], append(p.fmt(), src[end+1:]...)...)
 
 	if bytes.Equal(ori, res) {
-		return nil, nil
+		return ori, nil, nil
 	}
 
-	data, err := diff(ori, res, filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to diff: %v", err)
-	}
-
-	return data, nil
+	return ori, res, nil
 }

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -354,7 +354,7 @@ func Run(filename string, set *FlagSet) ([]byte, []byte, error) {
 	
 	// in case import flags are part of a codegen template, or otherwise "wrong"
 	if start+len(importStartFlag) > end {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	ret := bytes.Split(src[start+len(importStartFlag):end], []byte(linebreak))

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -145,7 +145,7 @@ func getPkgInfo(line string, comment bool) (string, string, string) {
 		if len(pkgArray) > 1 {
 			return pkgArray[1], pkgArray[0], fmt.Sprintf("%s%s%s", commentFlag, blank, strings.TrimSpace(s[1]))
 		} else {
-			return pkgArray[0], "", fmt.Sprintf("%s%s%s", commentFlag, blank, strings.TrimSpace(s[1]))
+			return strings.TrimSpace(pkgArray[0]), "", fmt.Sprintf("%s%s%s", commentFlag, blank, strings.TrimSpace(s[1]))
 		}
 	} else {
 		pkgArray := strings.Split(line, blank)


### PR DESCRIPTION
First change is to fix #7 

Second change is to fix a go file that only contained a string template used for go code generation.