### PR TITLE
Add support for multiple aliases and multiline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,5 +181,3 @@ import (
 ## TODO
 
 - Support multi-3rd-party packages
-- Support multiple lines of comment in import block
-- Add testcases

--- a/README.md
+++ b/README.md
@@ -204,6 +204,33 @@ import (
 )
 ```
 
+### with and without an alias and above multiline comment
+
+```go
+package main
+import (
+  "fmt"
+  "github.com/golang"
+  // a first line of comment
+  // a second line of comment
+  _ "github.com/golang"
+  "github.com/daixiang0"
+)
+```
+
+```go
+import (
+  "fmt"
+
+  // a first line of comment
+  // a second line of comment
+  _ "github.com/golang"
+  "github.com/golang"
+
+  "github.com/daixiang0"
+)
+```
+
 ## TODO
 
 - Support multi-3rd-party packages

--- a/README.md
+++ b/README.md
@@ -101,6 +101,32 @@ import (
 )
 ```
 
+### with and without an alias
+
+```go
+package main
+import (
+  "fmt"
+  "github.com/golang"
+  _ "github.com/golang"
+  "github.com/daixiang0"
+)
+```
+
+to
+
+```go
+package main
+import (
+  "fmt"
+
+  "github.com/golang"
+  _ "github.com/golang"
+
+  "github.com/daixiang0/gci"
+)
+```
+
 ### with comment and alias
 
 ```go

--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ import (
 )
 ```
 
+### with multiple aliases
+
+```go
+package main
+import (
+  "fmt"
+  a "github.com/golang"
+  b "github.com/golang"
+  "github.com/daixiang0"
+)
+```
+
+to
+
+```go
+package main
+import (
+  "fmt"
+
+  a "github.com/golang"
+  b "github.com/golang"
+
+  "github.com/daixiang0/gci"
+)
+```
+
 ### with comment and alias
 
 ```go

--- a/README.md
+++ b/README.md
@@ -152,6 +152,32 @@ import (
 )
 ```
 
+### with above multiline comment
+
+```go
+import (
+  "fmt"
+  // a first line of comment
+  // a second line of comment
+  _ "github.com/golang"
+  "github.com/daixiang0"
+)
+```
+
+to
+
+```go
+import (
+  "fmt"
+
+  // a first line of comment
+  // a second line of comment
+  _ "github.com/golang"
+
+  "github.com/daixiang0"
+)
+```
+
 ## TODO
 
 - Support multi-3rd-party packages

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 	"os"
 )
 
-
-
 var (
 	doWrite = flag.Bool("w", false, "doWrite result to (source) file instead of stdout")
 	doDiff  = flag.Bool("d", false, "display diffs instead of rewriting files")
@@ -36,7 +34,6 @@ func usage() {
 	flag.PrintDefaults()
 	os.Exit(2)
 }
-
 
 func main() {
 	flag.Usage = usage

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -83,9 +83,7 @@ func newPkg(data [][]byte, localFlag string) *pkg {
 			continue
 		} else if commentIndex > 0 {
 			pkg, alias, comment := getPkgInfo(line, true)
-			if alias != "" {
-				p.aliases[pkg] = append(p.aliases[pkg], alias)
-			}
+			p.aliases[pkg] = append(p.aliases[pkg], alias)
 
 			p.comment[pkg] = []string{comment}
 			pkgType := getPkgType(pkg, localFlag)
@@ -94,10 +92,7 @@ func newPkg(data [][]byte, localFlag string) *pkg {
 		}
 
 		pkg, alias, _ := getPkgInfo(line, false)
-
-		if alias != "" {
-			p.aliases[pkg] = append(p.aliases[pkg], alias)
-		}
+		p.aliases[pkg] = append(p.aliases[pkg], alias)
 
 		pkgType := getPkgType(pkg, localFlag)
 		p.list[pkgType][pkg] = true
@@ -129,7 +124,11 @@ func (p *pkg) fmt() []byte {
 			if len(p.aliases[s]) > 0 {
 				sort.Strings(p.aliases[s])
 				for _, alias := range p.aliases[s] {
-					ret = append(ret, fmt.Sprintf("%s%s%s%s%s", indent, alias, blank, s, linebreak))
+					if alias != "" {
+						ret = append(ret, fmt.Sprintf("%s%s%s%s%s", indent, alias, blank, s, linebreak))
+					} else {
+						ret = append(ret, fmt.Sprintf("%s%s%s", indent, s, linebreak))
+					}
 				}
 			} else {
 				ret = append(ret, fmt.Sprintf("%s%s%s", indent, s, linebreak))

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -267,8 +267,6 @@ func ProcessFile(filename string, out io.Writer, set *FlagSet) error {
 }
 
 func processFile(filename string, out io.Writer, set *FlagSet) error {
-	var err error
-
 	f, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -280,6 +278,10 @@ func processFile(filename string, out io.Writer, set *FlagSet) error {
 		return err
 	}
 
+	return processSource(filename, src, out, set)
+}
+
+func processSource(filename string, src []byte, out io.Writer, set *FlagSet) error {
 	ori := make([]byte, len(src))
 	copy(ori, src)
 	start := bytes.Index(src, importStartFlag)
@@ -303,7 +305,7 @@ func processFile(filename string, out io.Writer, set *FlagSet) error {
 			if fi, err := os.Stat(filename); err == nil {
 				perms = fi.Mode() & os.ModePerm
 			}
-			err = ioutil.WriteFile(filename, res, perms)
+			err := ioutil.WriteFile(filename, res, perms)
 			if err != nil {
 				return err
 			}
@@ -320,12 +322,12 @@ func processFile(filename string, out io.Writer, set *FlagSet) error {
 		}
 	}
 	if !*set.DoWrite && !*set.DoDiff {
-		if _, err = out.Write(res); err != nil {
+		if _, err := out.Write(res); err != nil {
 			return fmt.Errorf("failed to write: %v", err)
 		}
 	}
 
-	return err
+	return nil
 }
 
 func Run(filename string, set *FlagSet) ([]byte, error) {

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -54,7 +54,7 @@ import (
 `,
 		},
 		{
-			name:      "with alias",
+			name:      "with aliases",
 			localFlag: "github.com/daixiang0",
 			sourceImports: `
 import (
@@ -74,7 +74,29 @@ import (
 `,
 		},
 		{
-			name:      "with comment and alias",
+			name:      "with multiple aliases",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	a "github.com/golang"
+	b "github.com/golang"
+	"fmt"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	a "github.com/golang"
+	b "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+		{
+			name:      "with comment and aliases",
 			localFlag: "github.com/daixiang0",
 			sourceImports: `
 import (
@@ -95,7 +117,7 @@ import (
 `,
 		},
 		{
-			name:      "with above comment and alias",
+			name:      "with above comment and aliases",
 			localFlag: "github.com/daixiang0",
 			sourceImports: `
 import (

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -96,6 +96,28 @@ import (
 `,
 		},
 		{
+			name:      "with and without an alias",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"github.com/golang"
+	_ "github.com/golang"
+	"fmt"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	"github.com/golang"
+	_ "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+		{
 			name:      "with comment and aliases",
 			localFlag: "github.com/daixiang0",
 			sourceImports: `

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -1,0 +1,145 @@
+package gci
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProcessSource(t *testing.T) {
+	asGoFile := func(imports string) []byte {
+		return []byte(fmt.Sprintf(`package example
+
+%s
+
+func main() {
+	fmt.Println("hello world")
+}
+`, strings.TrimSpace(imports)))
+	}
+
+	type testCase struct {
+		name string
+
+		localFlag string
+		doWrite   bool
+		doDiff    bool
+
+		sourceImports   string
+		expectedImports string
+	}
+
+	testCases := []testCase{
+		{
+			name:      "simple case",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"golang.org/x/tools"
+
+	"fmt"
+
+	"github.com/daixiang0/gci"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	"golang.org/x/tools"
+
+	"github.com/daixiang0/gci"
+)
+`,
+		},
+		{
+			name:      "with alias",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	go "github.com/golang"
+	"fmt"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	go "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+		{
+			name:      "with comment and alias",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"fmt"
+	_ "github.com/golang" // golang
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	// golang
+	_ "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+		{
+			name:      "with above comment and alias",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"fmt"
+	// golang
+	_ "github.com/golang"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	// golang
+	_ "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			filename := "test_filename.go"
+			source := asGoFile(c.sourceImports)
+			expected := asGoFile(c.expectedImports)
+
+			var buffer bytes.Buffer
+			if err := processSource(filename, source, &buffer, &FlagSet{
+				LocalFlag: c.localFlag,
+				DoWrite:   &c.doWrite,
+				DoDiff:    &c.doDiff,
+			}); err != nil {
+				t.Errorf("failed to process source: %v", err)
+				t.FailNow()
+			}
+			actual := buffer.Bytes()
+
+			if bytes.Compare(expected, actual) != 0 {
+				diff, _ := diff(expected, actual, "")
+				t.Errorf("unexpected output %s", diff)
+				t.FailNow()
+			}
+		})
+	}
+}

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -138,6 +138,30 @@ import (
 )
 `,
 		},
+		{
+			name:      "with above multiline comment",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"fmt"
+	// a first line of comment
+	// a second line of comment
+	_ "github.com/golang"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	// a first line of comment
+	// a second line of comment
+	_ "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
 	}
 
 	for _, c := range testCases {

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -184,6 +184,59 @@ import (
 )
 `,
 		},
+		{
+			name:      "with multiple aliases and above multiline comment on first",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"fmt"
+	a "github.com/golang"
+	// a first line of comment
+	// a second line of comment
+	_ "github.com/golang"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	// a first line of comment
+	// a second line of comment
+	_ "github.com/golang"
+	a "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
+		{
+			name:      "with multiple aliases and above multiline comment on second",
+			localFlag: "github.com/daixiang0",
+			sourceImports: `
+import (
+	"fmt"
+	// a first line of comment
+	// a second line of comment
+	a "github.com/golang"
+	_ "github.com/golang"
+	"github.com/daixiang0"
+)
+`,
+			expectedImports: `
+import (
+	"fmt"
+
+	_ "github.com/golang"
+
+	// a first line of comment
+	// a second line of comment
+	a "github.com/golang"
+
+	"github.com/daixiang0"
+)
+`,
+		},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
There are 6 individual commits in this pull request:

1. Converts the examples in the README into test cases. No functional change, just made it easier to verify my work in the later two commits.
2. Adds support for multiple aliases (to resolve https://github.com/daixiang0/gci/issues/1).
3. Adds support for multi-line comments (to resolve https://github.com/daixiang0/gci/issues/13).
4. Removes the completed TODOs from the README.md file.
5. Add support for imports appearing multiple times (at least once with and once without an alias).
6. Fixes the bug I discuss in my comment blow where comments were being moved around if an import had multiple aliases.

Happy to split this changes into multiple pull requests if that would make reviewing easier. It was simpler while implementing them to build on top of the previous change with each new change.

My goal is that this is strictly backward compatible (so any file formatted with a current release of this formatter would not be changed with this version). It should resolve cases though where the previous current release of the formatter would have either removed comment information or duplicated an import statement.

Let me know if there is anything I can do to help clean up this change to make it easier to review.