### PR TITLE
chore: remove debug

### DIFF
--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -285,7 +285,6 @@ func processFile(filename string, out io.Writer, set *FlagSet) error {
 	start := bytes.Index(src, importStartFlag)
 	// in case no importStartFlag or importStartFlag exist in the commentFlag
 	if start < 0 {
-		fmt.Printf("skip file %s since no import\n", filename)
 		return nil
 	}
 	end := bytes.Index(src[start:], importEndFlag) + start


### PR DESCRIPTION
Hi 👋, I'm sorry to just delete the line, but since there is not logging system builtin yet, I prefer to make things simple and let you choose how you want to provide verbose logging later

Motivation: each time I run gci against my project, I got all the following lines, and since my plan is to run gci often (githooks, Makefile pre-rule, etc); I clearly need a default mode that only prints real problems.

I know that I can hack using pipefail or 3 step commands in Makefile, but it makes things a lot more complex.

    foo@bar:~ $ go run github.com/daixiang0/gci -w -local berty.tech .
    skip file cmd/berty/doc.go since no import
    skip file cmd/berty/mini/doc.go since no import
    skip file cmd/rdvp/doc.go since no import
    skip file framework/bertybridge/doc.go since no import
    skip file internal/cryptoutil/doc.go since no import
    skip file internal/discordlog/doc.go since no import
    skip file internal/grpcutil/doc.go since no import
    skip file internal/handshake/doc.go since no import
    skip file internal/ipfsutil/doc.go since no import
    skip file internal/multipeer-connectivity-transport/addr.go since no import
    skip file internal/multipeer-connectivity-transport/driver/bridge_unsupported.go since no import
    skip file internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_darwin.go since no import
    skip file internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_unsupported.go since no import
    skip file internal/notification/manager.go since no import
    skip file internal/notification/manager_noop.go since no import
    skip file internal/testutil/doc.go since no importskip file internal/tinder/doc.go since no import
    skip file pkg/banner/doc.go since no importskip file pkg/bertymessenger/doc.go since no import
    skip file pkg/bertymessenger/version.go since no importskip file pkg/bertyprotocol/doc.go since no import
    skip file pkg/bertytypes/doc.go since no importskip file pkg/bertytypes/events_account.go since no import
    skip file pkg/errcode/doc.go since no importskip file pkg/errcode/stdproto.go since no import

Thank you for this project 👍