### PR TITLE
Allow a comma-separated list of local prefixes, like goimports

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ var (
 	doWrite = flag.Bool("w", false, "doWrite result to (source) file instead of stdout")
 	doDiff  = flag.Bool("d", false, "display diffs instead of rewriting files")
 
-	localFlag string
+	localFlag []string
 
 	exitCode = 0
 )
@@ -27,9 +27,11 @@ func report(err error) {
 }
 
 func parseFlags() []string {
-	flag.StringVar(&localFlag, "local", "", "put imports beginning with this string after 3rd-party packages, only support one string")
+	var localFlagStr string
+	flag.StringVar(&localFlagStr, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
 
 	flag.Parse()
+	localFlag = gci.ParseLocalFlag(localFlagStr)
 	return flag.Args()
 }
 

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -15,23 +15,39 @@ func TestGetPkgType(t *testing.T) {
 		{Line: `"foo/pkg/bar"`, LocalFlag: "foo", ExpectedResult: local},
 		{Line: `"foo/pkg/bar"`, LocalFlag: "bar", ExpectedResult: remote},
 		{Line: `"foo/pkg/bar"`, LocalFlag: "github.com/foo/bar", ExpectedResult: remote},
+		{Line: `"foo/pkg/bar"`, LocalFlag: "github.com/foo", ExpectedResult: remote},
+		{Line: `"foo/pkg/bar"`, LocalFlag: "github.com/bar", ExpectedResult: remote},
+		{Line: `"foo/pkg/bar"`, LocalFlag: "github.com/foo,github.com/bar", ExpectedResult: remote},
+		{Line: `"foo/pkg/bar"`, LocalFlag: "github.com/foo,,github.com/bar", ExpectedResult: remote},
 
 		{Line: `"github.com/foo/bar"`, LocalFlag: "", ExpectedResult: remote},
 		{Line: `"github.com/foo/bar"`, LocalFlag: "foo", ExpectedResult: remote},
 		{Line: `"github.com/foo/bar"`, LocalFlag: "bar", ExpectedResult: remote},
 		{Line: `"github.com/foo/bar"`, LocalFlag: "github.com/foo/bar", ExpectedResult: local},
+		{Line: `"github.com/foo/bar"`, LocalFlag: "github.com/foo", ExpectedResult: local},
+		{Line: `"github.com/foo/bar"`, LocalFlag: "github.com/bar", ExpectedResult: remote},
+		{Line: `"github.com/foo/bar"`, LocalFlag: "github.com/foo,github.com/bar", ExpectedResult: local},
+		{Line: `"github.com/foo/bar"`, LocalFlag: "github.com/foo,,github.com/bar", ExpectedResult: local},
 
 		{Line: `"context"`, LocalFlag: "", ExpectedResult: standard},
 		{Line: `"context"`, LocalFlag: "context", ExpectedResult: local},
 		{Line: `"context"`, LocalFlag: "foo", ExpectedResult: standard},
 		{Line: `"context"`, LocalFlag: "bar", ExpectedResult: standard},
 		{Line: `"context"`, LocalFlag: "github.com/foo/bar", ExpectedResult: standard},
+		{Line: `"context"`, LocalFlag: "github.com/foo", ExpectedResult: standard},
+		{Line: `"context"`, LocalFlag: "github.com/bar", ExpectedResult: standard},
+		{Line: `"context"`, LocalFlag: "github.com/foo,github.com/bar", ExpectedResult: standard},
+		{Line: `"context"`, LocalFlag: "github.com/foo,,github.com/bar", ExpectedResult: standard},
 
 		{Line: `"os/signal"`, LocalFlag: "", ExpectedResult: standard},
 		{Line: `"os/signal"`, LocalFlag: "os/signal", ExpectedResult: local},
 		{Line: `"os/signal"`, LocalFlag: "foo", ExpectedResult: standard},
 		{Line: `"os/signal"`, LocalFlag: "bar", ExpectedResult: standard},
 		{Line: `"os/signal"`, LocalFlag: "github.com/foo/bar", ExpectedResult: standard},
+		{Line: `"os/signal"`, LocalFlag: "github.com/foo", ExpectedResult: standard},
+		{Line: `"os/signal"`, LocalFlag: "github.com/bar", ExpectedResult: standard},
+		{Line: `"os/signal"`, LocalFlag: "github.com/foo,github.com/bar", ExpectedResult: standard},
+		{Line: `"os/signal"`, LocalFlag: "github.com/foo,,github.com/bar", ExpectedResult: standard},
 	}
 
 	for _, tc := range testCases {
@@ -39,7 +55,7 @@ func TestGetPkgType(t *testing.T) {
 		t.Run(fmt.Sprintf("%s:%s", tc.Line, tc.LocalFlag), func(t *testing.T) {
 			t.Parallel()
 
-			result := getPkgType(tc.Line, tc.LocalFlag)
+			result := getPkgType(tc.Line, ParseLocalFlag(tc.LocalFlag))
 			if got, want := result, tc.ExpectedResult; got != want {
 				t.Errorf("bad result: %d, expected: %d", got, want)
 			}


### PR DESCRIPTION
`gci`'s limitation that it only takes a single prefix came as a surprise to me, and is blocking my employer from switching from `goimports` to `gci` (either way via `golangci-lint`) for multiple repos, and is forcing us to switch from `gci` to `goimports` on another.