### PR TITLE
Read from stdin when no file names are passed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,13 @@ func main() {
 		DoDiff:    doDiff,
 	}
 
+	if len(paths) == 0 {
+		if err := gci.ProcessFile("<standard input>", os.Stdin, os.Stdout, flagSet); err != nil {
+			report(err)
+		}
+		os.Exit(exitCode)
+	}
+
 	for _, path := range paths {
 		switch dir, err := os.Stat(path); {
 		case err != nil:
@@ -58,7 +65,7 @@ func main() {
 		case dir.IsDir():
 			report(gci.WalkDir(path, flagSet))
 		default:
-			if err := gci.ProcessFile(path, os.Stdout, flagSet); err != nil {
+			if err := gci.ProcessFile(path, nil, os.Stdout, flagSet); err != nil {
 				report(err)
 			}
 		}

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -258,7 +258,7 @@ func replaceTempFilename(diff []byte, filename string) ([]byte, error) {
 func visitFile(set *FlagSet) filepath.WalkFunc {
 	return func(path string, f os.FileInfo, err error) error {
 		if err == nil && isGoFile(f) {
-			err = processFile(path, os.Stdout, set)
+			err = processFile(path, nil, os.Stdout, set)
 		}
 		return err
 	}
@@ -274,20 +274,23 @@ func isGoFile(f os.FileInfo) bool {
 	return !f.IsDir() && !strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".go")
 }
 
-func ProcessFile(filename string, out io.Writer, set *FlagSet) error {
-	return processFile(filename, out, set)
+func ProcessFile(filename string, in io.Reader, out io.Writer, set *FlagSet) error {
+	return processFile(filename, in, out, set)
 }
 
-func processFile(filename string, out io.Writer, set *FlagSet) error {
+func processFile(filename string, in io.Reader, out io.Writer, set *FlagSet) error {
 	var err error
 
-	f, err := os.Open(filename)
-	if err != nil {
-		return err
+	if in == nil {
+		f, err := os.Open(filename)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		in = f
 	}
-	defer f.Close()
 
-	src, err := ioutil.ReadAll(f)
+	src, err := ioutil.ReadAll(in)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #12

I more-or-less copied the pattern used by `goimports`, both in [argument parsing](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.1.7:cmd/goimports/goimports.go;l=272-277) and in the [business logic](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.1.7:cmd/goimports/goimports.go;l=100-107).