### PR TITLE
Fix issue parsing block comments, and always retain prefix comments for cgo imports.

### DIFF
--- a/pkg/constants/sequences.go
+++ b/pkg/constants/sequences.go
@@ -1,9 +1,11 @@
 package constants
 
 const (
-	CommentFlag     = "//"
-	ImportStartFlag = "\nimport (\n"
-	ImportEndFlag   = "\n)"
+	LineCommentFlag       = "//"
+	BlockCommentStartFlag = "/*"
+	BlockCommentEndFlag   = "*/"
+	ImportStartFlag       = "\nimport (\n"
+	ImportEndFlag         = "\n)"
 
 	Blank     = " "
 	Indent    = "\t"

--- a/pkg/gci/imports/import.go
+++ b/pkg/gci/imports/import.go
@@ -56,7 +56,7 @@ func (i ImportDef) String() string {
 func (i ImportDef) Format(cfg configuration.FormatterConfiguration) string {
 	linePrefix := constants.Indent
 	var output string
-	if cfg.NoPrefixComments == false {
+	if cfg.NoPrefixComments == false || i.QuotedPath == `"C"` {
 		for _, prefixComment := range i.PrefixComment {
 			output += linePrefix + prefixComment + constants.Linebreak
 		}

--- a/pkg/gci/internal/testdata/cgo-block-mixed-with-content.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-mixed-with-content.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-block-mixed-with-content.in.go
+++ b/pkg/gci/internal/testdata/cgo-block-mixed-with-content.in.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	/* #include "types.h"
+	   #include "other.h" */"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-mixed-with-content.out.go
+++ b/pkg/gci/internal/testdata/cgo-block-mixed-with-content.out.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+		#include "other.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-mixed.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-mixed.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-block-mixed.in.go
+++ b/pkg/gci/internal/testdata/cgo-block-mixed.in.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	/* #include "types.h"
+	 */"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-mixed.out.go
+++ b/pkg/gci/internal/testdata/cgo-block-mixed.out.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-prefix.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-prefix.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-block-prefix.in.go
+++ b/pkg/gci/internal/testdata/cgo-block-prefix.in.go
@@ -1,0 +1,5 @@
+package main
+
+import (
+	/* #include "types.h" */ "C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-prefix.out.go
+++ b/pkg/gci/internal/testdata/cgo-block-prefix.out.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-single-line.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-single-line.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-block-single-line.in.go
+++ b/pkg/gci/internal/testdata/cgo-block-single-line.in.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	/* #include "types.h" */
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block-single-line.out.go
+++ b/pkg/gci/internal/testdata/cgo-block-single-line.out.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-block.in.go
+++ b/pkg/gci/internal/testdata/cgo-block.in.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-block.out.go
+++ b/pkg/gci/internal/testdata/cgo-block.out.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	/*
+		#include "types.h"
+	*/
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-line.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-line.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-line.in.go
+++ b/pkg/gci/internal/testdata/cgo-line.in.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	// #include "types.h"
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-line.out.go
+++ b/pkg/gci/internal/testdata/cgo-line.out.go
@@ -1,0 +1,6 @@
+package main
+
+import (
+	// #include "types.h"
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-multiline.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-multiline.cfg.yaml
@@ -1,0 +1,1 @@
+no-prefixComments: true

--- a/pkg/gci/internal/testdata/cgo-multiline.in.go
+++ b/pkg/gci/internal/testdata/cgo-multiline.in.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	// #include "types.h"
+	// #include "other.h"
+	"C"
+)

--- a/pkg/gci/internal/testdata/cgo-multiline.out.go
+++ b/pkg/gci/internal/testdata/cgo-multiline.out.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	// #include "types.h"
+	// #include "other.h"
+	"C"
+)

--- a/pkg/gci/parse.go
+++ b/pkg/gci/parse.go
@@ -10,25 +10,56 @@ import (
 // Recursively parses import lines into a list of ImportDefs
 func parseToImportDefinitions(unformattedLines []string) ([]importPkg.ImportDef, error) {
 	newImport := importPkg.ImportDef{}
+	inBlockComment := false
 	for index, unformattedLine := range unformattedLines {
 		line := strings.TrimSpace(unformattedLine)
 		if line == "" {
 			//empty line --> starts a new import
 			return parseToImportDefinitions(unformattedLines[index+1:])
 		}
-		if strings.HasPrefix(line, constants.CommentFlag) {
+		if strings.HasPrefix(line, constants.LineCommentFlag) {
 			// comment line
 			newImport.PrefixComment = append(newImport.PrefixComment, line)
 			continue
 		}
+
+		// FIXME: this doesn't correctly handle block comments that start part-way through a line or end part-way through a line, for example:
+		//   /* some comment */ "golang.org/x/tools"
+		// Or:
+		//  /* some comment
+		//  */ "golang.org/x/tools"
+		//
+		// It only supports block comments that start and end on their own line, for example:
+		//   /* some comment */
+		//   "golang.org/x/tools"
+		// Or:
+		//   /*
+		//     some comment
+		//   */
+		//   "golang.org/x/tools"
+		if inBlockComment {
+			if strings.HasSuffix(line, constants.BlockCommentEndFlag) {
+				inBlockComment = false
+			} else {
+				line = "\t" + line
+			}
+
+			newImport.PrefixComment = append(newImport.PrefixComment, line)
+			continue
+		} else if strings.HasPrefix(line, constants.BlockCommentStartFlag) {
+			inBlockComment = true
+			newImport.PrefixComment = append(newImport.PrefixComment, line)
+			continue
+		}
+
 		// split inline comment from import
-		importSegments := strings.SplitN(line, constants.CommentFlag, 2)
+		importSegments := strings.SplitN(line, constants.LineCommentFlag, 2)
 		switch len(importSegments) {
 		case 1:
 			// no inline comment
 		case 2:
 			// inline comment present
-			newImport.InlineComment = constants.CommentFlag + importSegments[1]
+			newImport.InlineComment = constants.LineCommentFlag + importSegments[1]
 		default:
 			return nil, InvalidImportSplitError{importSegments}
 		}


### PR DESCRIPTION
Resolves #48.

Comments before `import "C"` should always be retained, as these are used by cgo.