### PR TITLE
replace log with logrus

### DIFF
--- a/cmd/gci/root.go
+++ b/cmd/gci/root.go
@@ -6,9 +6,19 @@ import (
 
 	"github.com/daixiang0/gci/pkg/configuration"
 	"github.com/daixiang0/gci/pkg/gci"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	log.SetFormatter(&log.TextFormatter{
+		DisableColors: true,
+		FullTimestamp: true,
+	})
+
+	log.SetOutput(os.Stderr)
+}
 
 type Executor struct {
 	rootCmd    *cobra.Command
@@ -57,6 +67,10 @@ func (e *Executor) runInCompatibilityMode(cmd *cobra.Command, args []string) err
 	sections := gci.LocalFlagsToSections(*e.localFlags)
 	sectionSeparators := gci.DefaultSectionSeparators()
 	cfg := gci.GciConfiguration{configuration.FormatterConfiguration{false, false, false}, sections, sectionSeparators}
+	if cfg.Debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	if *e.writeMode {
 		return gci.WriteFormattedFiles(args, cfg)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/hexops/gotextdiff v1.0.3
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -14,11 +15,10 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kr/pretty v0.2.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.5.0 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -303,6 +304,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=

--- a/pkg/gci/format.go
+++ b/pkg/gci/format.go
@@ -3,13 +3,14 @@ package gci
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/daixiang0/gci/pkg/constants"
 	importPkg "github.com/daixiang0/gci/pkg/gci/imports"
 	sectionsPkg "github.com/daixiang0/gci/pkg/gci/sections"
 	"github.com/daixiang0/gci/pkg/gci/specificity"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Formats the import section of a Go file
@@ -45,9 +46,8 @@ func formatImportBlock(input []byte, cfg GciConfiguration) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("an error occured while trying to parse imports: %w", err)
 	}
-	if cfg.Debug {
-		log.Println("Parsed imports in file:", imports)
-	}
+	log.WithField("imports", imports).Debug("Parsed imports in file")
+
 	// create mapping between sections and imports
 	sectionMap := make(map[sectionsPkg.Section][]importPkg.ImportDef, len(cfg.Sections))
 	// find matching section for every importSpec
@@ -70,9 +70,8 @@ func formatImportBlock(input []byte, cfg GciConfiguration) ([]byte, error) {
 		if bestSection == nil {
 			return nil, NoMatchingSectionForImportError{i}
 		}
-		if cfg.Debug {
-			log.Printf("Matched import %s to section %s", i, bestSection)
-		}
+		log.WithField("import", i).WithField("section", bestSection).Debug("Matched import to section")
+
 		sectionMap[bestSection] = append(sectionMap[bestSection], i)
 	}
 	// format every section to a str
@@ -81,9 +80,7 @@ func formatImportBlock(input []byte, cfg GciConfiguration) ([]byte, error) {
 		sectionStr := section.Format(sectionMap[section], cfg.FormatterConfiguration)
 		// prevent adding an empty section which would cause a separator to be inserted
 		if sectionStr != "" {
-			if cfg.Debug {
-				log.Printf("Formatting section %s with imports: %v", section, sectionMap[section])
-			}
+			log.WithField("imports", sectionMap[section]).WithField("section", section).Debug("Formatting section with imports")
 			sectionStrings = append(sectionStrings, sectionStr)
 		}
 	}

--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	sectionsPkg "github.com/daixiang0/gci/pkg/gci/sections"
@@ -13,6 +12,7 @@ import (
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
 	"github.com/hexops/gotextdiff/span"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -52,10 +52,10 @@ func PrintFormattedFiles(paths []string, cfg GciConfiguration) error {
 func WriteFormattedFiles(paths []string, cfg GciConfiguration) error {
 	return processGoFilesInPaths(paths, cfg, func(filePath string, unmodifiedFile, formattedFile []byte) error {
 		if bytes.Equal(unmodifiedFile, formattedFile) {
-			log.Printf("Skipping correctly formatted File: %s", filePath)
+			log.WithField("file", filePath).Debug("Skipping correctly formatted file")
 			return nil
 		}
-		log.Printf("Writing formatted File: %s", filePath)
+		log.WithField("file", filePath).Info("Writing formatted file")
 		return os.WriteFile(filePath, formattedFile, 0644)
 	})
 }
@@ -109,7 +109,7 @@ func processingFunc(file io.FileObj, cfg GciConfiguration, formattingFunc fileFo
 
 func LoadFormatGoFile(file io.FileObj, cfg GciConfiguration) (unmodifiedFile, formattedFile []byte, err error) {
 	unmodifiedFile, err = file.Load()
-	log.Printf("Loaded File: %s", file.Path())
+	log.WithField("file", file.Path()).Debug("Loaded file")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,7 +120,7 @@ func LoadFormatGoFile(file io.FileObj, cfg GciConfiguration) (unmodifiedFile, fo
 		if !errors.Is(err, MissingImportStatementError) {
 			return unmodifiedFile, nil, err
 		}
-		log.Printf("File does not contain an import statement: %s", file.Path())
+		log.WithField("file", file.Path()).Debug("File does not contain an import statement")
 		formattedFile = unmodifiedFile
 	}
 	return unmodifiedFile, formattedFile, nil


### PR DESCRIPTION
This replaces the std lib log with [logrus](https://github.com/sirupsen/logrus) to enable structured logging and levels. I attempted to guess what levels things should live at, as well as moved some things to structured fields, and changed the default output to stderr. 

I can't get the tests to run correctly on my machine as they hang forever, but it seems to work.

Fixes #46 