### PR TITLE
Fix version output string

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/daixiang0/gci/cmd/gci"
 )
 
-var version = "0.3"
+var version = "0.4.2"
 
 func main() {
 	e := gci.NewExecutor(version)


### PR DESCRIPTION
Currently `gci` gives the wrong version when invoking it

```
./dist/gci -v
gci version 0.3
```

This just bumps the string to the correct version.