### PR TITLE
fix: invalid parsing

### DIFF
--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -122,7 +122,7 @@ func LoadFormatGoFile(file io.FileObj, cfg config.Config) (src, dist []byte, err
 		return src, src, nil
 	}
 
-	imports, headEnd, tailStart, tailEnd, err := parse.ParseFile(src)
+	imports, headEnd, tailStart, err := parse.ParseFile(src, file.Path())
 	if err != nil {
 		if errors.Is(err, parse.NoImportError{}) {
 			return src, src, nil
@@ -141,7 +141,7 @@ func LoadFormatGoFile(file io.FileObj, cfg config.Config) (src, dist []byte, err
 	}
 
 	head := src[:headEnd]
-	tail := src[tailStart:tailEnd]
+	tail := src[tailStart:]
 
 	// sort for custom sections
 	allKeys := make([]string, 0, len(result))

--- a/pkg/gci/internal/testdata/comment-in-the-tail.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment-in-the-tail.cfg.yaml
@@ -1,0 +1,4 @@
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment-in-the-tail.in.go
+++ b/pkg/gci/internal/testdata/comment-in-the-tail.in.go
@@ -1,0 +1,13 @@
+package main
+import (
+	"fmt"
+
+	g "github.com/golang"
+
+	"github.com/daixiang0/gci"
+)
+
+
+type test int
+
+// test

--- a/pkg/gci/internal/testdata/comment-in-the-tail.out.go
+++ b/pkg/gci/internal/testdata/comment-in-the-tail.out.go
@@ -1,0 +1,13 @@
+package main
+import (
+	"fmt"
+
+	g "github.com/golang"
+
+	"github.com/daixiang0/gci"
+)
+
+
+type test int
+
+// test

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -64,22 +64,31 @@ func getImports(imp *ast.ImportSpec) (start, end int, name string) {
 	return
 }
 
-func ParseFile(src []byte) (ImportList, int, int, int, error) {
-	parserMode := parser.Mode(0)
-	parserMode |= parser.ParseComments
+func ParseFile(src []byte, filename string) (ImportList, int, int, error) {
 	fileSet := token.NewFileSet()
-	f, err := parser.ParseFile(fileSet, "", src, parserMode)
+	f, err := parser.ParseFile(fileSet, filename, src, parser.ParseComments)
 	if err != nil {
-		return nil, 0, 0, 0, err
+		return nil, 0, 0, err
 	}
 
 	if len(f.Imports) == 0 {
-		return nil, 0, 0, 0, NoImportError{}
+		return nil, 0, 0, NoImportError{}
 	}
 
+	var headEnd int
+	var tailStart int
+
 	var data ImportList
-	for _, imp := range f.Imports {
+	for i, imp := range f.Imports {
 		start, end, name := getImports(imp)
+
+		if i == 0 {
+			headEnd = start
+		}
+		if i == len(f.Imports)-1 {
+			tailStart = end
+		}
+
 		data = append(data, &GciImports{
 			Start: start,
 			End:   end,
@@ -88,15 +97,11 @@ func ParseFile(src []byte) (ImportList, int, int, int, error) {
 		})
 	}
 
-	headEnd, _, _ := getImports(f.Imports[0])
-	_, tailStart, _ := getImports(f.Imports[len(f.Imports)-1])
-	tailEnd := f.Decls[len(f.Decls)-1].End()
-
 	sort.Sort(data)
-	return data, headEnd, tailStart, int(tailEnd), nil
+	return data, headEnd, tailStart, nil
 }
 
-// isGenerated reports whether the source file is generated code.
+// IsGeneratedFileByComment reports whether the source file is generated code.
 // Using a bit laxer rules than https://golang.org/s/generatedcode to
 // match more generated code.
 // Taken from https://github.com/golangci/golangci-lint.


### PR DESCRIPTION
```console
$ golangci-lint version 
golangci-lint has version 1.47.0 built from b4154027 on 2022-07-18T11:32:14Z

$ golangci-lint run                                                     
pkg/section/commentline_test.go:18  gci  File is not `gci`-ed with -skip-generated -s standard,default,prefix(github.com/daixiang0/gci)
pkg/section/default_test.go:16      gci  File is not `gci`-ed with -skip-generated -s standard,default,prefix(github.com/daixiang0/gci)
pkg/section/newline_test.go:17      gci  File is not `gci`-ed with -skip-generated -s standard,default,prefix(github.com/daixiang0/gci)
```