### PR TITLE
Change `README.md` instructions from `go get` to `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,18 @@ All import blocks use one TAB(`\t`) as Indent.
 
 `nolint` is hard to handle at section level, GCI will consider it as a single comment.
 
-## Download
+## Installation
+
+To download and install the highest available release version -
 
 ```shell
-$ go get github.com/daixiang0/gci
+$ go install github.com/daixiang0/gci@latest
+```
+
+You may also specify a specific version, for example:
+
+```shell
+$ go install github.com/daixiang0/gci@v0.6.0
 ```
 
 ## Usage


### PR DESCRIPTION
Simply running the current command from the `README.md` on more recent
go versions results in:

```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

This commits modifies the `README.md` to suggest `go install` instead