### PR TITLE
fix unintended modification of source when parsing input file

### DIFF
--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -156,8 +156,10 @@ func LoadFormatGoFile(file io.FileObj, cfg config.Config) (src, dist []byte, err
 		}
 	}
 
-	head := src[:headEnd]
-	tail := src[tailStart:]
+	head := make([]byte, headEnd)
+	copy(head, src[:headEnd])
+	tail := make([]byte, len(src)-tailStart)
+	copy(tail, src[tailStart:])
 
 	head = append(head, utils.Linebreak)
 	// add beginning of import block

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -1,13 +1,13 @@
 package gci
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/daixiang0/gci/pkg/config"
 	"github.com/daixiang0/gci/pkg/io"
@@ -44,11 +44,17 @@ func TestRun(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, formattedFile, err := LoadFormatGoFile(io.File{FilePath: fileBaseName + ".in.go"}, *gciCfg)
+			inputSrcFile := io.File{FilePath: fileBaseName + ".in.go"}
+			inputSrc, err := inputSrcFile.Load()
+			require.NoError(t, err)
+
+			unmodifiedFile, formattedFile, err := LoadFormatGoFile(inputSrcFile, *gciCfg)
 			if err != nil {
 				t.Fatal(err)
 			}
-			expectedOutput, err := ioutil.ReadFile(fileBaseName + ".out.go")
+			assert.Equal(t, inputSrc, unmodifiedFile)
+
+			expectedOutput, err := os.ReadFile(fileBaseName + ".out.go")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
head and tail should be based on copies of the actual src.

this fixes unintended modification of the underlying shared byte array which results in diffs and unncecessary writes.

should fix https://github.com/daixiang0/gci/issues/125