### PR TITLE
fix go vet issue

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -73,7 +73,7 @@ func runAnalysis(pass *analysis.Pass) (interface{}, error) {
 
 	for _, file := range fileReferences {
 		filePath := file.Name()
-		unmodifiedFile, formattedFile, err := gci.LoadFormatGoFile(io.File{filePath}, *gciCfg)
+		unmodifiedFile, formattedFile, err := gci.LoadFormatGoFile(io.File{FilePath: filePath}, *gciCfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fixes the following reported `go vet ` issue

```
go vet ./...
# github.com/daixiang0/gci/pkg/analyzer
pkg/analyzer/analyzer.go:76:62: github.com/daixiang0/gci/pkg/io.File composite literal uses unkeyed fields
```