### PR TITLE
feat: Support multiple prefixes to group them together and/or a regex #107

### DIFF
--- a/pkg/section/parser_test.go
+++ b/pkg/section/parser_test.go
@@ -40,6 +40,11 @@ func TestParse(t *testing.T) {
 			expectedSection: nil,
 			expectedError:   errors.New("invalid params: prefix("),
 		},
+		{
+			input:           []string{"prefix(domainA;domainB)"},
+			expectedSection: SectionList{Custom{"domainA;domainB"}},
+			expectedError:   nil,
+		},
 	}
 	for _, test := range testCases {
 		parsedSection, err := Parse(test.input)

--- a/pkg/section/prefix.go
+++ b/pkg/section/prefix.go
@@ -15,9 +15,12 @@ type Custom struct {
 const CustomType = "custom"
 
 func (c Custom) MatchSpecificity(spec *parse.GciImports) specificity.MatchSpecificity {
-	if strings.HasPrefix(spec.Path, c.Prefix) {
-		return specificity.Match{Length: len(c.Prefix)}
+	for _, prefix := range strings.Split(c.Prefix, ";") {
+		if strings.HasPrefix(spec.Path, prefix) {
+			return specificity.Match{Length: len(prefix)}
+		}
 	}
+
 	return specificity.MisMatch{}
 }
 


### PR DESCRIPTION
```gci write -s standard -s default -s 'Prefix(alt.code.company.com;code.company.com)' --custom-order --skip-generated .```

Should yield:
```
import (
  "fmt"

  "github.com/daixiang0/gci"

  "alt.code.company.com/foo/boo"
  "code.company.com/foo/bar/baz"
)```