### PR TITLE
Flexible inspection of stdlib

### DIFF
--- a/pkg/section/standard.go
+++ b/pkg/section/standard.go
@@ -1,6 +1,8 @@
 package section
 
 import (
+	"strings"
+
 	"github.com/daixiang0/gci/pkg/parse"
 	"github.com/daixiang0/gci/pkg/specificity"
 )
@@ -25,6 +27,8 @@ func (s Standard) Type() string {
 }
 
 func isStandard(pkg string) bool {
-	_, ok := standardPackages[pkg]
-	return ok
+	if index := strings.Index(pkg, "/"); index != -1 {
+		pkg = pkg[:index]
+	}
+	return !strings.Contains(pkg, ".")
 }


### PR DESCRIPTION
Here's another #138. After updated to go1.20, gci considers crypto/ecdh as an external dependency. 

This fix solved my problem and should work most of the time, but you may still need to check for a local module name without a domain.