### PR TITLE
feature: support multiple prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ GCI, a tool that controls golang package import order and makes it always determ
 The desired output format is highly configurable and allows for more custom formatting than `goimport` does.
 
 GCI considers a import block based on AST as below:
+
 ```
 Doc
 Name Path Comment
 ```
+
 All comments will keep as they were, except the isolated comment blocks.
 
 The isolated comment blocks like below:
+
 ```
 import (
   "fmt" 
@@ -78,9 +81,9 @@ Flags:
   -h, --help              help for write
   -s, --section strings   Sections define how inputs will be processed. Section names are case-insensitive and may contain parameters in (). The section order is standard > default > custom > blank > dot. The default value is [standard,default].
                           standard - standard section that Golang provides officially, like "fmt"
-                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix.
+                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix. Multiple custom prefixes may be provided, they will be rendered as distinct sections separated by newline. You can regroup multiple prefixes by separating them with comma: Prefix(github.com/daixiang0,gitlab.com/daixiang0,daixiang0)
                           default - default section, contains all rest imports
-                          blank - blank section, contains all blank imports. This section is not presed unless explicitly enabled. (default [standard,default])
+                          blank - blank section, contains all blank imports.
       --skip-generated    Skip generated files
       --custom-order      Enable custom order of sections. If specified, make the section order the same as your configuration order. The default order is standard > default > custom > blank > dot.
 ```
@@ -99,11 +102,11 @@ Flags:
   -d, --debug             Enables debug output from the formatter
   -h, --help              help for write
   -s, --section strings   Sections define how inputs will be processed. Section names are case-insensitive and may contain parameters in (). The section order is standard > default > custom > blank > dot. The default value is [standard,default].
-                          standard - standard section thatolang provides officially, like "fmt"
-                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix.
+                          standard - standard section that Golang provides officially, like "fmt"
+                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix. Multiple custom prefixes may be provided, they will be rendered as distinct sections separated by newline. You can regroup multiple prefixes by separating them with comma: Prefix(github.com/daixiang0,gitlab.com/daixiang0,daixiang0)
                           default - default section, contains all rest imports
-                          blank - blank section, contains all blank imports. This section is not presed unless explicitly enabled.
-                          dot - dot section, contains all dot imports. This section is not presed unless explicitly enabled. (default [standard,default])
+                          blank - blank section, contains all blank imports.
+                          dot - dot section, contains all dot imports.
       --skip-generated    Skip generated files
       --custom-order      Enable custom order of sections. If specified, make the section order the same as your configuration order. The default order is standard > default > custom > blank > dot.
 ```
@@ -119,11 +122,11 @@ Flags:
   -d, --debug             Enables debug output from the formatter
   -h, --help              help for write
   -s, --section strings   Sections define how inputs will be processed. Section names are case-insensitive and may contain parameters in (). The section order is standard > default > custom > blank > dot. The default value is [standard,default].
-                          standard - standard section thatolang provides officially, like "fmt"
-                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix.
+                          standard - standard section that Golang provides officially, like "fmt"
+                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix. Multiple custom prefixes may be provided, they will be rendered as distinct sections separated by newline. You can regroup multiple prefixes by separating them with comma: Prefix(github.com/daixiang0,gitlab.com/daixiang0,daixiang0)
                           default - default section, contains all rest imports
-                          blank - blank section, contains all blank imports. This section is not presed unless explicitly enabled.
-                          dot - dot section, contains all dot imports. This section is not presed unless explicitly enabled. (default [standard,default])
+                          blank - blank section, contains all blank imports.
+                          dot - dot section, contains all dot imports.
       --skip-generated    Skip generated files
       --custom-order      Enable custom order of sections. If specified, make the section order the same as your configuration order. The default order is standard > default > custom > blank > dot.
 ```

--- a/cmd/gci/gcicommand.go
+++ b/cmd/gci/gcicommand.go
@@ -49,15 +49,15 @@ func (e *Executor) newGciCommand(use, short, long string, aliases []string, stdI
 
 	sectionHelp := `Sections define how inputs will be processed. Section names are case-insensitive and may contain parameters in (). The section order is standard > default > custom > blank > dot. The default value is [standard,default].
 standard - standard section that Golang provides officially, like "fmt"
-Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix.
+Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix. Multiple custom prefixes may be provided, they will be rendered as distinct sections separated by newline. You can regroup multiple prefixes by separating them with comma: Prefix(github.com/daixiang0,gitlab.com/daixiang0,daixiang0)
 default - default section, contains all rest imports
-blank - blank section, contains all blank imports. This section is not presed unless explicitly enabled.
-dot - dot section, contains all dot imports. This section is not presed unless explicitly enabled.`
+blank - blank section, contains all blank imports.
+dot - dot section, contains all dot imports.`
 
 	skipGenerated = cmd.Flags().Bool("skip-generated", false, "Skip generated files")
 
 	customOrder = cmd.Flags().Bool("custom-order", false, "Enable custom order of sections")
-	sectionStrings = cmd.Flags().StringSliceP("section", "s", section.DefaultSections().String(), sectionHelp)
+	sectionStrings = cmd.Flags().StringArrayP("section", "s", section.DefaultSections().String(), sectionHelp)
 
 	// deprecated
 	noInlineComments = cmd.Flags().Bool("NoInlineComments", false, "Drops inline comments while formatting")

--- a/pkg/gci/internal/testdata/grouped-multiple-custom.cfg.yaml
+++ b/pkg/gci/internal/testdata/grouped-multiple-custom.cfg.yaml
@@ -1,0 +1,4 @@
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0,gitlab.com/daixiang0,daixiang0)

--- a/pkg/gci/internal/testdata/grouped-multiple-custom.in.go
+++ b/pkg/gci/internal/testdata/grouped-multiple-custom.in.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"daixiang0/lib1"
+	"fmt"
+	"github.com/daixiang0/gci"
+	"gitlab.com/daixiang0/gci"
+	g "github.com/golang"
+	"github.com/daixiang0/gci/subtest"
+)

--- a/pkg/gci/internal/testdata/grouped-multiple-custom.out.go
+++ b/pkg/gci/internal/testdata/grouped-multiple-custom.out.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	g "github.com/golang"
+
+	"daixiang0/lib1"
+	"github.com/daixiang0/gci"
+	"github.com/daixiang0/gci/subtest"
+	"gitlab.com/daixiang0/gci"
+)

--- a/pkg/section/parser_test.go
+++ b/pkg/section/parser_test.go
@@ -40,6 +40,11 @@ func TestParse(t *testing.T) {
 			expectedSection: nil,
 			expectedError:   errors.New("invalid params: prefix("),
 		},
+		{
+			input:           []string{"prefix(domainA,domainB)"},
+			expectedSection: SectionList{Custom{"domainA,domainB"}},
+			expectedError:   nil,
+		},
 	}
 	for _, test := range testCases {
 		parsedSection, err := Parse(test.input)

--- a/pkg/section/prefix.go
+++ b/pkg/section/prefix.go
@@ -12,12 +12,19 @@ type Custom struct {
 	Prefix string
 }
 
+// CustomSeparator allows you to group multiple custom prefix together in the same section
+// gci diff -s standard -s default -s prefix(github.com/company,gitlab.com/company,companysuffix)
+const CustomSeparator = ","
+
 const CustomType = "custom"
 
 func (c Custom) MatchSpecificity(spec *parse.GciImports) specificity.MatchSpecificity {
-	if strings.HasPrefix(spec.Path, c.Prefix) {
-		return specificity.Match{Length: len(c.Prefix)}
+	for _, prefix := range strings.Split(c.Prefix, CustomSeparator) {
+		if strings.HasPrefix(spec.Path, prefix) {
+			return specificity.Match{Length: len(prefix)}
+		}
 	}
+
 	return specificity.MisMatch{}
 }
 


### PR DESCRIPTION
Fix #107 

This PR includes the changes made in #134 by @luw2007


```
gci write -s standard -s default -s 'Prefix(alt.code.company.com,code.company.com)' --custom-order --skip-generated .
```

Should yield:

```
  "fmt"

  "github.com/daixiang0/gci"

  "alt.code.company.com/foo/boo"
  "code.company.com/foo/bar/baz"
)
```