### PR TITLE
fix: bump version for v0.9.2 to align '--version' with the tagged installation

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/daixiang0/gci/cmd/gci"
 )
 
-var version = "0.9.0"
+var version = "0.9.2"
 
 func main() {
 	e := gci.NewExecutor(version)


### PR DESCRIPTION
Resolves #143