### PR TITLE
support suggested fixes by analyzing a diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/hexops/gotextdiff v1.0.3
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
@@ -15,7 +16,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/pkg/analyzer/diff.go
+++ b/pkg/analyzer/diff.go
@@ -1,0 +1,83 @@
+package analyzer
+
+import (
+	"bytes"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"golang.org/x/tools/go/analysis"
+)
+
+var hunkRE = regexp.MustCompile(`@@ -(\d+),(\d+) \+\d+,\d+ @@`)
+
+func GetSuggestedFix(file *token.File, a, b []byte) (*analysis.SuggestedFix, error) {
+	d := difflib.UnifiedDiff{
+		A:       difflib.SplitLines(string(a)),
+		B:       difflib.SplitLines(string(b)),
+		Context: 1,
+	}
+	diff, err := difflib.GetUnifiedDiffString(d)
+	if err != nil {
+		return nil, err
+	}
+	if diff == "" {
+		return nil, nil
+	}
+	var (
+		fix   analysis.SuggestedFix
+		found = false
+		edit  analysis.TextEdit
+		buf   bytes.Buffer
+	)
+	for _, line := range strings.Split(diff, "\n") {
+		if hunk := hunkRE.FindStringSubmatch(line); len(hunk) > 0 {
+			if found {
+				edit.NewText = buf.Bytes()
+				buf = bytes.Buffer{}
+				fix.TextEdits = append(fix.TextEdits, edit)
+				edit = analysis.TextEdit{}
+			}
+			found = true
+			start, err := strconv.Atoi(hunk[1])
+			if err != nil {
+				return nil, err
+			}
+			lines, err := strconv.Atoi(hunk[2])
+			if err != nil {
+				return nil, err
+			}
+			edit.Pos = file.LineStart(start)
+			end := start + lines
+			if end > file.LineCount() {
+				edit.End = token.Pos(file.Size())
+			} else {
+				edit.End = file.LineStart(end)
+			}
+			continue
+		}
+		// skip any lines until first hunk found
+		if !found {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case '+':
+			buf.WriteString(line[1:])
+			buf.WriteRune('\n')
+		case '-':
+			// just skip
+		default:
+			buf.WriteString(line)
+			buf.WriteRune('\n')
+		}
+	}
+	edit.NewText = buf.Bytes()
+	fix.TextEdits = append(fix.TextEdits, edit)
+
+	return &fix, nil
+}

--- a/pkg/analyzer/diff_test.go
+++ b/pkg/analyzer/diff_test.go
@@ -1,0 +1,127 @@
+package analyzer_test
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/daixiang0/gci/pkg/analyzer"
+)
+
+const formattedFile = `package analyzer
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/daixiang0/gci/pkg/config"
+	"github.com/daixiang0/gci/pkg/gci"
+	"github.com/daixiang0/gci/pkg/io"
+	"github.com/daixiang0/gci/pkg/log"
+)
+`
+
+func TestGetSuggestedFix(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		unformattedFile string
+		expectedFix     *analysis.SuggestedFix
+		expectedErr     string
+	}{
+		{
+			name:            "same files",
+			unformattedFile: formattedFile,
+		},
+		{
+			name: "one change",
+			unformattedFile: `package analyzer
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/daixiang0/gci/pkg/config"
+	"github.com/daixiang0/gci/pkg/gci"
+
+	"github.com/daixiang0/gci/pkg/io"
+	"github.com/daixiang0/gci/pkg/log"
+)
+`,
+			expectedFix: &analysis.SuggestedFix{
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos: 133,
+						End: 205,
+						NewText: []byte(` 	"github.com/daixiang0/gci/pkg/gci"
+ 	"github.com/daixiang0/gci/pkg/io"
+`,
+						),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple changes",
+			unformattedFile: `package analyzer
+
+import (
+	"fmt"
+	"go/token"
+
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/daixiang0/gci/pkg/config"
+	"github.com/daixiang0/gci/pkg/gci"
+
+	"github.com/daixiang0/gci/pkg/io"
+	"github.com/daixiang0/gci/pkg/log"
+)
+`,
+			expectedFix: &analysis.SuggestedFix{
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos: 35,
+						End: 59,
+						NewText: []byte(` 	"go/token"
+ 	"strings"
+`,
+						),
+					},
+					{
+						Pos: 134,
+						End: 206,
+						NewText: []byte(` 	"github.com/daixiang0/gci/pkg/gci"
+ 	"github.com/daixiang0/gci/pkg/io"
+`,
+						),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "analyzer.go", tt.unformattedFile, 0)
+			assert.NoError(t, err)
+
+			actualFix, err := analyzer.GetSuggestedFix(fset.File(f.Pos()), []byte(tt.unformattedFile), []byte(formattedFile))
+			if tt.expectedErr != "" {
+				assert.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedFix, actualFix)
+		})
+	}
+}


### PR DESCRIPTION
Added `GetSuggestedFix` function creates unified diff for `unmodifiedFile` and `formattedFile`.
Then analyzes the diff and creates `analysis.SuggestedFix` if needed.

The Analyzer checks the result of `GetSuggestedFix` function and reports as `analysis.Diagnostic`.

Removed the `inspect.Analyzer` dependency since it is not used, but requires extra work

Fix #146 