### PR TITLE
fix an issue with extra space in unified diff

### DIFF
--- a/pkg/analyzer/diff.go
+++ b/pkg/analyzer/diff.go
@@ -71,8 +71,8 @@ func GetSuggestedFix(file *token.File, a, b []byte) (*analysis.SuggestedFix, err
 			buf.WriteRune('\n')
 		case '-':
 			// just skip
-		default:
-			buf.WriteString(line)
+		case ' ':
+			buf.WriteString(line[1:])
 			buf.WriteRune('\n')
 		}
 	}

--- a/pkg/analyzer/diff_test.go
+++ b/pkg/analyzer/diff_test.go
@@ -61,8 +61,8 @@ import (
 					{
 						Pos: 133,
 						End: 205,
-						NewText: []byte(` 	"github.com/daixiang0/gci/pkg/gci"
- 	"github.com/daixiang0/gci/pkg/io"
+						NewText: []byte(`	"github.com/daixiang0/gci/pkg/gci"
+	"github.com/daixiang0/gci/pkg/io"
 `,
 						),
 					},
@@ -93,16 +93,16 @@ import (
 					{
 						Pos: 35,
 						End: 59,
-						NewText: []byte(` 	"go/token"
- 	"strings"
+						NewText: []byte(`	"go/token"
+	"strings"
 `,
 						),
 					},
 					{
 						Pos: 134,
 						End: 206,
-						NewText: []byte(` 	"github.com/daixiang0/gci/pkg/gci"
- 	"github.com/daixiang0/gci/pkg/io"
+						NewText: []byte(`	"github.com/daixiang0/gci/pkg/gci"
+	"github.com/daixiang0/gci/pkg/io"
 `,
 						),
 					},


### PR DESCRIPTION
The GetUnifiedDiffString returns all lines with an extra character at beginning of each line: `+`, `-`, ` ` (space).

The code properly handled the `+` and `-`, but not handled ` ` (space) character at all.
So all changed code got an additional space at the beginning of each line.
This change fixes the issue.

Issue is not critical, because simple `go fmt` removes that space and this is the reason I didn't catch it earlier.