### PR TITLE
Fix line endings for CRLF (windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# test inputs should be platform depend
+*.in.go text eol=auto
+
+# formatted test results should always end on \n instead of \r\n
+*.out.go text eol=lf

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -75,7 +75,7 @@ func (g YamlConfig) Parse() (*Config, error) {
 
 func InitializeGciConfigFromYAML(filePath string) (*Config, error) {
 	config := YamlConfig{}
-	yamlData, err := ioutil.ReadFile(filePath)
+	yamlData, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -2,7 +2,6 @@ package gci
 
 import (
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -26,10 +25,6 @@ func isTestInputFile(_ string, file os.FileInfo) bool {
 }
 
 func TestRun(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows")
-	}
-
 	testFiles, err := io.FindFilesForPath(testFilesPath, isTestInputFile)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/gci/internal/testdata/already-good.cfg.yaml
+++ b/pkg/gci/internal/testdata/already-good.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/blank-format.cfg.yaml
+++ b/pkg/gci/internal/testdata/blank-format.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-after-import.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-after-import.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-before-import.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-before-import.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-mixed-with-content.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-mixed-with-content.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-mixed.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-mixed.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-prefix.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-prefix.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block-single-line.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block-single-line.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-block.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-block.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-line.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-line.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-multiline.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-multiline.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/cgo-single.cfg.yaml
+++ b/pkg/gci/internal/testdata/cgo-single.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment-before-import.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment-before-import.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment-top.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment-top.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment-whithout-whitespace.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment-whithout-whitespace.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment-with-slashslash.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment-with-slashslash.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/comment.cfg.yaml
+++ b/pkg/gci/internal/testdata/comment.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/leading-comment.cfg.yaml
+++ b/pkg/gci/internal/testdata/leading-comment.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/multiple-imports.cfg.yaml
+++ b/pkg/gci/internal/testdata/multiple-imports.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/multiple-line-comment.cfg.yaml
+++ b/pkg/gci/internal/testdata/multiple-line-comment.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/no-format.cfg.yaml
+++ b/pkg/gci/internal/testdata/no-format.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/nochar-after-import.cfg.yaml
+++ b/pkg/gci/internal/testdata/nochar-after-import.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/nolint.cfg.yaml
+++ b/pkg/gci/internal/testdata/nolint.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/number-in-alias.cfg.yaml
+++ b/pkg/gci/internal/testdata/number-in-alias.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/one-import-one-line.cfg.yaml
+++ b/pkg/gci/internal/testdata/one-import-one-line.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/one-import.cfg.yaml
+++ b/pkg/gci/internal/testdata/one-import.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/simple-case.cfg.yaml
+++ b/pkg/gci/internal/testdata/simple-case.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/whitespace-test.cfg.yaml
+++ b/pkg/gci/internal/testdata/whitespace-test.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/with-above-comment-and-alias.cfg.yaml
+++ b/pkg/gci/internal/testdata/with-above-comment-and-alias.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/gci/internal/testdata/with-comment-and-alias.cfg.yaml
+++ b/pkg/gci/internal/testdata/with-comment-and-alias.cfg.yaml
@@ -1,1 +1,4 @@
-common.cfg.yaml
+sections:
+  - Standard
+  - Default
+  - Prefix(github.com/daixiang0)

--- a/pkg/section/newline_test.go
+++ b/pkg/section/newline_test.go
@@ -11,6 +11,7 @@ func TestNewLineSpecificity(t *testing.T) {
 		{`""`, NewLine{}, specificity.MisMatch{}},
 		{`"x"`, NewLine{}, specificity.MisMatch{}},
 		{`"\n"`, NewLine{}, specificity.MisMatch{}},
+		{`"\r\n"`, NewLine{}, specificity.MisMatch{}},
 	}
 	testSpecificity(t, testCases)
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,9 +1,11 @@
 package utils
 
 const (
-	Indent       = '\t'
-	Linebreak    = '\n'
-	WinLinebreak = '\r'
+	Indent = '\t'
+
+	Linebreak = '\n'
+
+	WinLinebreak = "\r\n"
 
 	Colon = ":"
 


### PR DESCRIPTION
Fix line endings for windows.

Currently the replacing of line endings is wrong and too late. Rather than replacing "\r\n" which represents a windows line ending only "\r" is replaced resulting in double line endings on files with CRLF-endings.

Unfortunalty just adjusting the replacement from "\r" to "\r\n" breaks the formatting as the parser above also depends on UNIX-lineendings.

TODO:
- [ ]  unmarshalling does not work on windows (the common config does not auto resolve) @daixiang0  would be cool, if you could provide some input on how the unmarshaling works