### PR TITLE
Fix out of range panics

### DIFF
--- a/pkg/gci/testdata.go
+++ b/pkg/gci/testdata.go
@@ -1275,4 +1275,24 @@ import (
 )
 `,
 	},
+	{
+		"no-trailing-newline",
+
+		`sections:
+  - Standard
+`,
+		`package main
+
+import (
+	"net"
+	"fmt"
+)`,
+		`package main
+
+import (
+	"fmt"
+	"net"
+)
+`,
+	},
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -111,6 +111,9 @@ func ParseFile(src []byte, filename string) (ImportList, int, int, int, int, err
 					headEnd = int(decl.Pos()) - 1
 				}
 				tailStart = int(decl.End())
+				if tailStart > len(src) {
+					tailStart = len(src)
+				}
 
 				for _, spec := range genDecl.Specs {
 					imp := spec.(*ast.ImportSpec)


### PR DESCRIPTION
If the input is an incorrectly sorted list of imports, and the file consist only of import section not followed by a newline, the code panics with `makeslice: len out of range`