### PR TITLE
Update standard library list for go1.22.0

### DIFF
--- a/pkg/section/standard_list.go
+++ b/pkg/section/standard_list.go
@@ -1,6 +1,6 @@
 package section
 
-// Code generated based on go1.21.0 X:arenas. DO NOT EDIT.
+// Code generated based on go1.22.0 X:arenas. DO NOT EDIT.
 
 var standardPackages = map[string]struct{}{
 	"archive/tar":          {},
@@ -78,6 +78,7 @@ var standardPackages = map[string]struct{}{
 	"go/scanner":           {},
 	"go/token":             {},
 	"go/types":             {},
+	"go/version":           {},
 	"hash":                 {},
 	"hash/adler32":         {},
 	"hash/crc32":           {},
@@ -106,6 +107,7 @@ var standardPackages = map[string]struct{}{
 	"math/bits":            {},
 	"math/cmplx":           {},
 	"math/rand":            {},
+	"math/rand/v2":         {},
 	"mime":                 {},
 	"mime/multipart":       {},
 	"mime/quotedprintable": {},


### PR DESCRIPTION
Go 1.22.0 introduced two new packages (`go/version`, `math/rand/v2`), update library list accordingly.