### PR TITLE
Enhance LocalModule when no go sources found in project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Since v0.9.0, GCI always puts C import block as the first.
 
 ### LocalModule
 
-Local module detection is done via listing packages from *the directory where
-`gci` is invoked* and reading the modules off these. This means:
+Local module detection is done via reading the module name from the `go.mod`
+file in *the directory where `gci` is invoked*. This means:
 
   - This mode works when `gci` is invoked from a module root (i.e. directory
     containing `go.mod`)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/mod v0.8.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/tools v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -19,6 +20,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 )

--- a/pkg/gci/testdata.go
+++ b/pkg/gci/testdata.go
@@ -1295,27 +1295,4 @@ import (
 )
 `,
 	},
-	{
-		"basic module",
-		// implicitly relies on the local module name being: github.com/daixiang0/gci
-		`sections:
-  - Standard
-  - LocalModule
-`,
-		`package main
-
-import (
-	"os"
-	"github.com/daixiang0/gci/cmd/gci"
-)
-`,
-		`package main
-
-import (
-	"os"
-
-	"github.com/daixiang0/gci/cmd/gci"
-)
-`,
-	},
 }

--- a/pkg/gci/testdata/module_canonical/.gitattributes
+++ b/pkg/gci/testdata/module_canonical/.gitattributes
@@ -1,0 +1,4 @@
+# try and stop git running on Windows from converting line endings from
+# in all Go files under this directory. This is to avoid inconsistent test
+# results when `gci` strips "\r" characters
+**/*.go eol=lf

--- a/pkg/gci/testdata/module_canonical/cmd/client/main.go
+++ b/pkg/gci/testdata/module_canonical/cmd/client/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"example.com/service/internal"
+	"example.com/service/internal/bar"
+	"example.com/service/internal/foo"
+	"golang.org/x/net"
+	"log"
+)

--- a/pkg/gci/testdata/module_canonical/cmd/client/main.out.go
+++ b/pkg/gci/testdata/module_canonical/cmd/client/main.out.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+
+	"golang.org/x/net"
+
+	"example.com/service/internal"
+	"example.com/service/internal/bar"
+	"example.com/service/internal/foo"
+)

--- a/pkg/gci/testdata/module_canonical/cmd/server/main.go
+++ b/pkg/gci/testdata/module_canonical/cmd/server/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"example.com/service/internal"
+	"example.com/service/internal/bar"
+	"example.com/service/internal/foo"
+	"golang.org/x/net"
+	"log"
+)

--- a/pkg/gci/testdata/module_canonical/cmd/server/main.out.go
+++ b/pkg/gci/testdata/module_canonical/cmd/server/main.out.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+
+	"golang.org/x/net"
+
+	"example.com/service/internal"
+	"example.com/service/internal/bar"
+	"example.com/service/internal/foo"
+)

--- a/pkg/gci/testdata/module_canonical/config.yaml
+++ b/pkg/gci/testdata/module_canonical/config.yaml
@@ -1,0 +1,4 @@
+sections:
+  - Standard
+  - Default
+  - LocalModule

--- a/pkg/gci/testdata/module_canonical/go.mod
+++ b/pkg/gci/testdata/module_canonical/go.mod
@@ -1,0 +1,3 @@
+module example.com/service
+
+go 1.20

--- a/pkg/gci/testdata/module_canonical/internal/bar/lib.go
+++ b/pkg/gci/testdata/module_canonical/internal/bar/lib.go
@@ -1,0 +1,1 @@
+package bar

--- a/pkg/gci/testdata/module_canonical/internal/foo/lib.go
+++ b/pkg/gci/testdata/module_canonical/internal/foo/lib.go
@@ -1,0 +1,6 @@
+package foo
+
+import (
+	"example.com/service/internal/bar"
+	"log"
+)

--- a/pkg/gci/testdata/module_canonical/internal/foo/lib.out.go
+++ b/pkg/gci/testdata/module_canonical/internal/foo/lib.out.go
@@ -1,0 +1,7 @@
+package foo
+
+import (
+	"log"
+
+	"example.com/service/internal/bar"
+)

--- a/pkg/gci/testdata/module_canonical/internal/lib.go
+++ b/pkg/gci/testdata/module_canonical/internal/lib.go
@@ -1,0 +1,1 @@
+package internal

--- a/pkg/gci/testdata/module_noncanonical/.gitattributes
+++ b/pkg/gci/testdata/module_noncanonical/.gitattributes
@@ -1,0 +1,4 @@
+# try and stop git running on Windows from converting line endings from
+# in all Go files under this directory. This is to avoid inconsistent test
+# results when `gci` strips "\r" characters
+**/*.go eol=lf

--- a/pkg/gci/testdata/module_noncanonical/cmd/client/main.go
+++ b/pkg/gci/testdata/module_noncanonical/cmd/client/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"golang.org/x/net"
+	"log"
+	"service/internal"
+	"service/internal/bar"
+	"service/internal/foo"
+)

--- a/pkg/gci/testdata/module_noncanonical/cmd/client/main.out.go
+++ b/pkg/gci/testdata/module_noncanonical/cmd/client/main.out.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+
+	"golang.org/x/net"
+
+	"service/internal"
+	"service/internal/bar"
+	"service/internal/foo"
+)

--- a/pkg/gci/testdata/module_noncanonical/cmd/server/main.go
+++ b/pkg/gci/testdata/module_noncanonical/cmd/server/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"golang.org/x/net"
+	"log"
+	"service/internal"
+	"service/internal/bar"
+	"service/internal/foo"
+)

--- a/pkg/gci/testdata/module_noncanonical/cmd/server/main.out.go
+++ b/pkg/gci/testdata/module_noncanonical/cmd/server/main.out.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+
+	"golang.org/x/net"
+
+	"service/internal"
+	"service/internal/bar"
+	"service/internal/foo"
+)

--- a/pkg/gci/testdata/module_noncanonical/config.yaml
+++ b/pkg/gci/testdata/module_noncanonical/config.yaml
@@ -1,0 +1,4 @@
+sections:
+  - Standard
+  - Default
+  - LocalModule

--- a/pkg/gci/testdata/module_noncanonical/go.mod
+++ b/pkg/gci/testdata/module_noncanonical/go.mod
@@ -1,0 +1,3 @@
+module service
+
+go 1.20

--- a/pkg/gci/testdata/module_noncanonical/internal/bar/lib.go
+++ b/pkg/gci/testdata/module_noncanonical/internal/bar/lib.go
@@ -1,0 +1,1 @@
+package bar

--- a/pkg/gci/testdata/module_noncanonical/internal/foo/lib.go
+++ b/pkg/gci/testdata/module_noncanonical/internal/foo/lib.go
@@ -1,0 +1,6 @@
+package foo
+
+import (
+	"log"
+	"service/internal/bar"
+)

--- a/pkg/gci/testdata/module_noncanonical/internal/foo/lib.out.go
+++ b/pkg/gci/testdata/module_noncanonical/internal/foo/lib.out.go
@@ -1,0 +1,7 @@
+package foo
+
+import (
+	"log"
+
+	"service/internal/bar"
+)

--- a/pkg/gci/testdata/module_noncanonical/internal/lib.go
+++ b/pkg/gci/testdata/module_noncanonical/internal/lib.go
@@ -1,0 +1,1 @@
+package internal


### PR DESCRIPTION
👋 

Four days ago, a remarkable feature was added — LocalModule. It's an incredibly cool addition that has proven to be useful to many, including myself and my teams.

However, there might be instances where the Go source files are not located in the project's root folder. I've demonstrated what this could look like in a test.

Such an enhancement would be very beneficial. I'm eager to receive feedback from the community and, if possible, apply the suggested improvement.