### PR TITLE
fix: local module path matching

### DIFF
--- a/pkg/section/local_module.go
+++ b/pkg/section/local_module.go
@@ -18,7 +18,7 @@ type LocalModule struct {
 }
 
 func (m *LocalModule) MatchSpecificity(spec *parse.GciImports) specificity.MatchSpecificity {
-	if strings.HasPrefix(spec.Path, m.Path) {
+	if spec.Path == m.Path || strings.HasPrefix(spec.Path, m.Path+"/") {
 		return specificity.LocalModule{}
 	}
 

--- a/pkg/section/local_module_test.go
+++ b/pkg/section/local_module_test.go
@@ -1,0 +1,18 @@
+package section
+
+import (
+	"testing"
+
+	"github.com/daixiang0/gci/pkg/specificity"
+)
+
+func TestLocalModule_specificity(t *testing.T) {
+	testCases := []specificityTestData{
+		{"example.com/hello", &LocalModule{Path: "example.com/hello"}, specificity.LocalModule{}},
+		{"example.com/hello/world", &LocalModule{Path: "example.com/hello"}, specificity.LocalModule{}},
+		{"example.com/hello-world", &LocalModule{Path: "example.com/hello"}, specificity.MisMatch{}},
+		{"example.com/helloworld", &LocalModule{Path: "example.com/hello"}, specificity.MisMatch{}},
+		{"example.com", &LocalModule{Path: "example.com/hello"}, specificity.MisMatch{}},
+	}
+	testSpecificity(t, testCases)
+}


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/issues/4608

The value `path` can't end with `/` because a module name can't end with `/`, so the append of `/` doesn't need to be checked.

This PR has no problem with modules without packages (`spec.Path == m.Path`).

Closes #203