### PR TITLE
Update local_module.go

### DIFF
--- a/pkg/section/local_module.go
+++ b/pkg/section/local_module.go
@@ -46,6 +46,10 @@ func (m *LocalModule) Configure(path string) error {
 		m.Path = path
 	}
 
+	if !strings.HasSuffix(m.Path, "/") {
+		m.Path += "/"
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add a trailing slash for LocalModules, to differentiate between similarly named but different packages.