### PR TITLE
fix: scrape all goos/goarch pair for stdlib

### DIFF
--- a/internal/generate.go
+++ b/internal/generate.go
@@ -94,12 +94,10 @@ func generate() error {
 	for _, pair := range strings.Split(list, "\n") {
 		pair := pair
 		g.Go(func() error {
-			parts := strings.Split(pair, "\t")
-			if len(parts) != 2 {
+			goos, goarch, found := strings.Cut(pair, "\t")
+			if !found {
 				return nil
 			}
-			goos := parts[0]
-			goarch := parts[1]
 
 			pkgs, err := packages.Load(&packages.Config{
 				Mode: packages.NeedName,

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"go/format"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"text/template"
 
 	"golang.org/x/tools/go/packages"
@@ -35,25 +38,109 @@ func main() {
 	}
 }
 
+// update from https://go.dev/doc/install/source#environment
+var list = `aix	ppc64
+android	386
+android	amd64
+android	arm
+android	arm64
+darwin	amd64
+darwin	arm64
+dragonfly	amd64
+freebsd	386
+freebsd	amd64
+freebsd	arm
+illumos	amd64
+ios	arm64
+js	wasm
+linux	386
+linux	amd64
+linux	arm
+linux	arm64
+linux	loong64
+linux	mips
+linux	mipsle
+linux	mips64
+linux	mips64le
+linux	ppc64
+linux	ppc64le
+linux	riscv64
+linux	s390x
+netbsd	386
+netbsd	amd64
+netbsd	arm
+openbsd	386
+openbsd	amd64
+openbsd	arm
+openbsd	arm64
+plan9	386
+plan9	amd64
+plan9	arm
+solaris	amd64
+wasip1	wasm
+windows	386
+windows	amd64
+windows	arm
+windows	arm64`
+
 func generate() error {
-	all, err := packages.Load(nil, "std")
-	if err != nil {
-		return err
+	var all []*packages.Package
+
+	writeLock := sync.Mutex{}
+	wg := sync.WaitGroup{}
+
+	pairs := strings.Split(list, "\n")
+	for _, pair := range pairs {
+		wg.Add(1)
+		go func(pair string) {
+			defer wg.Done()
+
+			parts := strings.Split(pair, "\t")
+			if len(parts) != 2 {
+				return
+			}
+			goos := parts[0]
+			goarch := parts[1]
+
+			pkgs, err := packages.Load(&packages.Config{
+				Mode: packages.NeedName,
+				Env:  append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch, "GOEXPERIMENT=arenas,boringcrypto"),
+			}, "std")
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println("loaded", goos, goarch, len(pkgs))
+
+			writeLock.Lock()
+			defer writeLock.Unlock()
+
+			all = append(all, pkgs...)
+		}(pair)
 	}
 
-	var pkgs []string
+	wg.Wait()
+
+	var pkgSet = make(map[string]struct{})
 
 	// go list std | grep -v vendor | grep -v internal
 	for _, pkg := range all {
 		if !strings.Contains(pkg.PkgPath, "internal") && !strings.Contains(pkg.PkgPath, "vendor") {
-			pkgs = append(pkgs, pkg.PkgPath)
+			pkgSet[pkg.PkgPath] = struct{}{}
 		}
 	}
+
+	var pkgs []string
+	for pkg := range pkgSet {
+		pkgs = append(pkgs, pkg)
+	}
+
+	slices.Sort(pkgs)
 
 	file, err := os.Create(outputFile)
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	models := map[string]interface{}{
 		"Packages": pkgs,

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -129,7 +129,7 @@ func generate() error {
 		}
 	}
 
-	var pkgs []string
+	pkgs := make([]string, 0, len(pkgSet))
 	for pkg := range pkgSet {
 		pkgs = append(pkgs, pkg)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,11 +64,11 @@ func (g YamlConfig) Parse() (*Config, error) {
 		sort.Slice(sections, func(i, j int) bool {
 			sectionI, sectionJ := sections[i].Type(), sections[j].Type()
 
-			if g.Cfg.NoLexOrder || strings.Compare(sectionI, sectionJ) != 0 {
+			if g.Cfg.NoLexOrder || sectionI != sectionJ {
 				return defaultOrder[sectionI] < defaultOrder[sectionJ]
 			}
 
-			return strings.Compare(sections[i].String(), sections[j].String()) < 0
+			return sections[i].String() < sections[j].String()
 		})
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"sort"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 

--- a/pkg/section/standard_list.go
+++ b/pkg/section/standard_list.go
@@ -156,6 +156,7 @@ var standardPackages = map[string]struct{}{
 	"sync":                 {},
 	"sync/atomic":          {},
 	"syscall":              {},
+	"syscall/js":           {},
 	"testing":              {},
 	"testing/fstest":       {},
 	"testing/iotest":       {},

--- a/pkg/section/standard_test.go
+++ b/pkg/section/standard_test.go
@@ -15,6 +15,7 @@ func TestStandardPackageSpecificity(t *testing.T) {
 		{"crypto/ae", Standard{}, specificity.MisMatch{}},
 		{"crypto/aes", Standard{}, specificity.StandardMatch{}},
 		{"crypto/aes2", Standard{}, specificity.MisMatch{}},
+		{"syscall/js", Standard{}, specificity.StandardMatch{}},
 	}
 	testSpecificity(t, testCases)
 }


### PR DESCRIPTION
Closes: #209 

Now `syscall/js` can be recognized correctly.

