### PR TITLE
Update standard library list for go 1.23

### DIFF
--- a/pkg/section/standard_list.go
+++ b/pkg/section/standard_list.go
@@ -1,6 +1,6 @@
 package section
 
-// Code generated based on go1.22.0 X:boringcrypto,arenas. DO NOT EDIT.
+// Code generated based on go1.23.0 X:boringcrypto,arenas. DO NOT EDIT.
 
 var standardPackages = map[string]struct{}{
 	"archive/tar":          {},
@@ -100,6 +100,7 @@ var standardPackages = map[string]struct{}{
 	"io":                   {},
 	"io/fs":                {},
 	"io/ioutil":            {},
+	"iter":                 {},
 	"log":                  {},
 	"log/slog":             {},
 	"log/syslog":           {},
@@ -151,6 +152,7 @@ var standardPackages = map[string]struct{}{
 	"sort":                 {},
 	"strconv":              {},
 	"strings":              {},
+	"structs":              {},
 	"sync":                 {},
 	"sync/atomic":          {},
 	"syscall":              {},
@@ -168,5 +170,6 @@ var standardPackages = map[string]struct{}{
 	"unicode":              {},
 	"unicode/utf16":        {},
 	"unicode/utf8":         {},
+	"unique":               {},
 	"unsafe":               {},
 }


### PR DESCRIPTION
It'd be great to get a release after the standard library list is updated as well (so golangci-lint and such can better support Go 1.23).

Fixes #207