### PR TITLE
enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,10 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/daixiang0/gci
+  testifylint:
+    disable:
+    - useless-assert
+    enable-all: true
 
 linters:
   disable-all: true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/daixiang0/gci/pkg/section"
 )
@@ -14,7 +15,7 @@ func TestParseOrder(t *testing.T) {
 		SectionStrings: []string{"default", "prefix(github/daixiang0/gci)", "prefix(github/daixiang0/gai)"},
 	}
 	gciCfg, err := cfg.Parse()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, section.SectionList{section.Default{}, section.Custom{Prefix: "github/daixiang0/gai"}, section.Custom{Prefix: "github/daixiang0/gci"}}, gciCfg.Sections)
 }
 
@@ -26,7 +27,7 @@ func TestParseCustomOrder(t *testing.T) {
 		},
 	}
 	gciCfg, err := cfg.Parse()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, section.SectionList{section.Default{}, section.Custom{Prefix: "github/daixiang0/gci"}, section.Custom{Prefix: "github/daixiang0/gai"}}, gciCfg.Sections)
 }
 
@@ -39,6 +40,6 @@ func TestParseNoLexOrder(t *testing.T) {
 	}
 
 	gciCfg, err := cfg.Parse()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, section.SectionList{section.Default{}, section.Custom{Prefix: "github/daixiang0/gci"}, section.Custom{Prefix: "github/daixiang0/gai"}}, gciCfg.Sections)
 }

--- a/pkg/gci/gci_test.go
+++ b/pkg/gci/gci_test.go
@@ -33,7 +33,7 @@ func TestRun(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testCases[i].in, string(old))
 			assert.Equal(t, testCases[i].out, string(new))
 		})

--- a/pkg/section/errors_test.go
+++ b/pkg/section/errors_test.go
@@ -1,25 +1,24 @@
 package section
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorMatching(t *testing.T) {
-	assert.True(t, errors.Is(MissingParameterClosingBracketsError, MissingParameterClosingBracketsError))
-	assert.True(t, errors.Is(MoreThanOneOpeningQuotesError, MoreThanOneOpeningQuotesError))
-	assert.True(t, errors.Is(SectionTypeDoesNotAcceptParametersError, SectionTypeDoesNotAcceptParametersError))
-	assert.True(t, errors.Is(SectionTypeDoesNotAcceptPrefixError, SectionTypeDoesNotAcceptPrefixError))
-	assert.True(t, errors.Is(SectionTypeDoesNotAcceptSuffixError, SectionTypeDoesNotAcceptSuffixError))
+	require.ErrorIs(t, MissingParameterClosingBracketsError, MissingParameterClosingBracketsError)
+	require.ErrorIs(t, MoreThanOneOpeningQuotesError, MoreThanOneOpeningQuotesError)
+	require.ErrorIs(t, SectionTypeDoesNotAcceptParametersError, SectionTypeDoesNotAcceptParametersError)
+	require.ErrorIs(t, SectionTypeDoesNotAcceptPrefixError, SectionTypeDoesNotAcceptPrefixError)
+	require.ErrorIs(t, SectionTypeDoesNotAcceptSuffixError, SectionTypeDoesNotAcceptSuffixError)
 }
 
 func TestErrorClass(t *testing.T) {
 	subError := MissingParameterClosingBracketsError
 	errorGroup := SectionParsingError{subError}
-	assert.True(t, errors.Is(errorGroup, SectionParsingError{}))
-	assert.True(t, errors.Is(errorGroup, subError))
-	assert.True(t, errors.Is(errorGroup.Wrap("x"), SectionParsingError{}))
-	assert.True(t, errors.Is(errorGroup.Wrap("x"), subError))
+	require.ErrorIs(t, errorGroup, SectionParsingError{})
+	require.ErrorIs(t, errorGroup, subError)
+	require.ErrorIs(t, errorGroup.Wrap("x"), SectionParsingError{})
+	require.ErrorIs(t, errorGroup.Wrap("x"), subError)
 }


### PR DESCRIPTION
#### Description 

[testifylint](https://golangci-lint.run/usage/linters/#testifylint) checks usage of github.com/stretchr/testify.