### PR TITLE
Offer a non-zero exit code when formatting is needed with `--check`

### DIFF
--- a/cmd/gci/gcicommand.go
+++ b/cmd/gci/gcicommand.go
@@ -12,7 +12,7 @@ import (
 type processingFunc = func(args []string, gciCfg config.Config) error
 
 func (e *Executor) newGciCommand(use, short, long string, aliases []string, stdInSupport bool, processingFunc processingFunc) *cobra.Command {
-	var noInlineComments, noPrefixComments, skipGenerated, skipVendor, customOrder, noLexOrder, debug *bool
+	var noInlineComments, noPrefixComments, skipGenerated, skipVendor, customOrder, noLexOrder, debug, check *bool
 	var sectionStrings, sectionSeparatorStrings *[]string
 	cmd := cobra.Command{
 		Use:               use,
@@ -29,6 +29,7 @@ func (e *Executor) newGciCommand(use, short, long string, aliases []string, stdI
 				SkipVendor:       *skipVendor,
 				CustomOrder:      *customOrder,
 				NoLexOrder:       *noLexOrder,
+				Check:            *check,
 			}
 			gciCfg, err := config.YamlConfig{Cfg: fmtCfg, SectionStrings: *sectionStrings, SectionSeparatorStrings: *sectionSeparatorStrings}.Parse()
 			if err != nil {
@@ -63,6 +64,7 @@ localmodule: localmodule section, contains all imports from local packages`
 
 	customOrder = cmd.Flags().Bool("custom-order", false, "Enable custom order of sections")
 	noLexOrder = cmd.Flags().Bool("no-lex-order", false, "Drops lexical ordering for custom sections")
+	check = cmd.Flags().Bool("check", false, "Exit with non-zero status if files need formatting")
 	sectionStrings = cmd.Flags().StringArrayP("section", "s", section.DefaultSections().String(), sectionHelp)
 
 	// deprecated

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type BoolConfig struct {
 	SkipVendor       bool `yaml:"skipVendor"`
 	CustomOrder      bool `yaml:"customOrder"`
 	NoLexOrder       bool `yaml:"noLexOrder"`
+	Check            bool `yaml:"-"`
 }
 
 type Config struct {


### PR DESCRIPTION
Hey there, thanks for the great tool!

Sometime you want the exit code to be something else than 0, e.g. in a CI workflow or more generally if you want to use gci as a linter, so I've added a `--check` flag to `list` and `diff` subcommands that exits with status 1 when changes are needed.

Hope you're interested in such a change, and feel free to ask for any modification if needed.