### PR TITLE
fix: preserve standalone comments in import blocks

### DIFF
--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -172,6 +172,37 @@ func LoadFormat(in []byte, path string, cfg config.Config) (src, dist []byte, er
 		}
 	}
 
+	// Preserve standalone line comments in the import block that are not
+	// associated with any import spec (e.g. // +kubebuilder:scaffold:imports).
+	// Only "//" line comments are preserved; standalone "/* */" block comments
+	// are not supported because go/format merges them with the closing ")",
+	// producing non-idempotent output.
+	lastImportEnd := 0
+	for _, d := range imports {
+		lastImportEnd = max(lastImportEnd, d.End)
+	}
+	if lastImportEnd > 0 && lastImportEnd < tailStart {
+		scanEnd := tailStart
+		// If C import block exists after the last regular import, stop before it
+		if cStart > lastImportEnd && cStart < scanEnd {
+			scanEnd = cStart
+		}
+		// Zero-allocation line scanning using bytes.Cut
+		remaining := src[lastImportEnd:scanEnd]
+		linebreak := []byte{utils.Linebreak}
+		commentPrefix := []byte("//")
+		for len(remaining) > 0 {
+			var line []byte
+			line, remaining, _ = bytes.Cut(remaining, linebreak)
+			trimmed := bytes.TrimSpace(line)
+			if bytes.HasPrefix(trimmed, commentPrefix) {
+				body = append(body, utils.Indent)
+				body = append(body, trimmed...)
+				body = append(body, utils.Linebreak)
+			}
+		}
+	}
+
 	head := make([]byte, headEnd)
 	copy(head, src[:headEnd])
 	tail := make([]byte, len(src)-tailStart)

--- a/pkg/gci/testdata.go
+++ b/pkg/gci/testdata.go
@@ -1295,4 +1295,165 @@ import (
 )
 `,
 	},
+	{
+		"kubebuilder-scaffold-imports",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"os"
+	"fmt"
+	// +kubebuilder:scaffold:imports
+)
+`,
+		`package main
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
+	{
+		"kubebuilder-scaffold-imports-with-third-party",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"os"
+	"fmt"
+
+	"github.com/golang"
+
+	"github.com/daixiang0/gci"
+	// +kubebuilder:scaffold:imports
+)
+`,
+		`package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang"
+
+	"github.com/daixiang0/gci"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
+	{
+		"standalone-comment-already-sorted",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+)
+`,
+		`package main
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
+	{
+		"multiple-standalone-comments",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"os"
+	"fmt"
+	// +kubebuilder:scaffold:imports
+	// another standalone comment
+)
+`,
+		`package main
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+	// another standalone comment
+)
+`,
+	},
+	{
+		"standalone-comment-with-cgo-before",
+
+		commonConfig,
+
+		`package main
+
+// #include <png.h>
+import "C"
+
+import (
+	"os"
+	"fmt"
+	// +kubebuilder:scaffold:imports
+)
+`,
+		`package main
+
+// #include <png.h>
+import "C"
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
+	{
+		"standalone-comment-with-cgo-after",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"os"
+	"fmt"
+
+	"github.com/daixiang0/gci"
+	g "github.com/golang"
+	// +kubebuilder:scaffold:imports
+)
+
+// #include <png.h>
+import "C"
+`,
+		`package main
+
+// #include <png.h>
+import "C"
+
+import (
+	"fmt"
+	"os"
+
+	g "github.com/golang"
+
+	"github.com/daixiang0/gci"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
 }


### PR DESCRIPTION
Fixes #135.

GCI was removing standalone line comments (e.g. `// +kubebuilder:scaffold:imports`) from import blocks when reformatting imports.

### Limitations

Only `//` line comments are preserved. Standalone `/* */` block comments as the last element before `)` are not supported because `go/format` merges them with the closing `)`, producing non-idempotent output.