### PR TITLE
Preserve orphan comments (e.g. kubebuilder scaffold marker) inside import blocks

### DIFF
--- a/pkg/gci/gci.go
+++ b/pkg/gci/gci.go
@@ -137,7 +137,7 @@ func LoadFormat(in []byte, path string, cfg config.Config) (src, dist []byte, er
 		return src, src, nil
 	}
 
-	imports, headEnd, tailStart, cStart, cEnd, err := parse.ParseFile(src, path)
+	imports, headEnd, tailStart, cStart, cEnd, tailCommentStart, tailCommentEnd, err := parse.ParseFile(src, path)
 	if err != nil {
 		if errors.Is(err, parse.NoImportError{}) {
 			return src, src, nil
@@ -186,6 +186,17 @@ func LoadFormat(in []byte, path string, cfg config.Config) (src, dist []byte, er
 	// add beginning of import block
 	head = append(head, `import (`...)
 	head = append(head, utils.Linebreak)
+
+	// Preserve any standalone comment that lived inside the import block but
+	// was not attached to a specific import spec (e.g. code-generation
+	// markers such as `// +kubebuilder:scaffold:imports`). Without this,
+	// such comments are silently dropped because body is only ever built
+	// from the byte ranges of recognized import specs above.
+	if tailCommentStart >= 0 && tailCommentEnd > tailCommentStart {
+		body = append(body, utils.Linebreak, utils.Indent)
+		body = append(body, src[tailCommentStart:tailCommentEnd]...)
+	}
+
 	// add end of import block
 	body = append(body, []byte{utils.RightParenthesis, utils.Linebreak}...)
 

--- a/pkg/gci/testdata.go
+++ b/pkg/gci/testdata.go
@@ -1295,4 +1295,26 @@ import (
 )
 `,
 	},
+	{
+		"trailing-marker-comment",
+
+		commonConfig,
+
+		`package main
+
+import (
+	"os"
+	"fmt"
+	// +kubebuilder:scaffold:imports
+)
+`,
+		`package main
+
+import (
+	"fmt"
+	"os"
+	// +kubebuilder:scaffold:imports
+)
+`,
+	},
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -70,15 +70,50 @@ func getImports(imp *ast.ImportSpec) (start, end int, name string) {
 	return
 }
 
-func ParseFile(src []byte, filename string) (ImportList, int, int, int, int, error) {
+// findTailComment looks for a comment group that sits inside the import
+// block, after the last recognized import spec but before the closing
+// parenthesis, and is therefore not attached (as Doc or Comment) to any
+// *ast.ImportSpec. Tools such as kubebuilder/controller-gen rely on a
+// standalone marker comment in exactly this position (e.g.
+// `// +kubebuilder:scaffold:imports`) to know where to insert future
+// imports, so it must be preserved across formatting instead of silently
+// dropped. Returns (-1, -1) if no such comment exists.
+func findTailComment(f *ast.File, data ImportList, tailStart int) (start, end int) {
+	start, end = -1, -1
+
+	if len(data) == 0 || tailStart == 0 {
+		return
+	}
+
+	lastImportEnd := 0
+	for _, d := range data {
+		if d.End > lastImportEnd {
+			lastImportEnd = d.End
+		}
+	}
+
+	for _, cg := range f.Comments {
+		cgStart := int(cg.Pos()) - 1
+		cgEnd := int(cg.End())
+		if cgStart >= lastImportEnd && cgEnd < tailStart {
+			if start == -1 {
+				start = cgStart
+			}
+			end = cgEnd
+		}
+	}
+	return
+}
+
+func ParseFile(src []byte, filename string) (ImportList, int, int, int, int, int, int, error) {
 	fileSet := token.NewFileSet()
 	f, err := parser.ParseFile(fileSet, filename, src, parser.ParseComments)
 	if err != nil {
-		return nil, 0, 0, 0, 0, err
+		return nil, 0, 0, 0, 0, -1, -1, err
 	}
 
 	if len(f.Imports) == 0 {
-		return nil, 0, 0, 0, 0, NoImportError{}
+		return nil, 0, 0, 0, 0, -1, -1, NoImportError{}
 	}
 
 	var (
@@ -161,8 +196,13 @@ func ParseFile(src []byte, filename string) (ImportList, int, int, int, int, err
 		}
 	}
 
+	// Find any standalone comment that lives inside the import block but is
+	// not attached to a specific import spec, so callers can preserve it
+	// instead of losing it when the block is rewritten.
+	tailCommentStart, tailCommentEnd := findTailComment(f, data, tailStart)
+
 	sort.Sort(data)
-	return data, headEnd, tailStart, cStart, cEnd, nil
+	return data, headEnd, tailStart, cStart, cEnd, tailCommentStart, tailCommentEnd, nil
 }
 
 // IsGeneratedFileByComment reports whether the source file is generated code.


### PR DESCRIPTION
## Summary

Fixes #135. Since PR #120 ("optimize detect import blocks"), `gci` silently drops any comment inside an import block that isn't attached (as `Doc` or trailing `Comment`) to a specific `*ast.ImportSpec`. That PR's own description acknowledged this as a known breaking change ("introduce breaking change: remove isolated comments").

The most common way to hit this is a standalone marker comment such as:

```go
import (
	"os"
	"fmt"
	// +kubebuilder:scaffold:imports
)
```

kubebuilder/controller-gen relies on that comment being present at that exact position to know where to insert future imports. Running `gci` on such a file removes the marker entirely, which breaks the codegen workflow.

## Root cause

`pkg/parse/parse.go`'s `ParseFile` only records byte ranges for import specs (`Start`/`End` derived from each spec's `Doc`/`Name`/`Path`/`Comment`). `pkg/gci/gci.go`'s `LoadFormat` rebuilds the import block purely by concatenating those recorded byte ranges, so any comment that isn't formally attached to a spec never makes it into the rewritten output.

## Change

- `pkg/parse/parse.go`: added `findTailComment`, which scans `f.Comments` for a comment group that sits after the last recognized import spec but before the import block's closing paren (i.e. not attached to any spec). `ParseFile` now additionally returns that comment's byte range (`-1, -1` if none exists).
- `pkg/gci/gci.go`: `LoadFormat` takes the two new return values and, right before appending the closing `)`, re-inserts the orphan comment's original bytes so it survives the rewrite.
- `pkg/gci/testdata.go`: added a `trailing-marker-comment` test case reproducing the exact example from the issue.

The change is intentionally scoped to the trailing-comment case described in the issue (a comment between the last import and the closing paren). A related but distinct case mentioned in the issue discussion — a leading orphan comment ending up merged onto the `import (` line — is not addressed here to keep this change minimal and focused.

## Testing

Added `trailing-marker-comment` to `pkg/gci/testdata.go`'s `testCases`, which is exercised by the existing `TestRun` in `pkg/gci/gci_test.go`:

```go
in: `package main

import (
	"os"
	"fmt"
	// +kubebuilder:scaffold:imports
)
`,
out: `package main

import (
	"fmt"
	"os"
	// +kubebuilder:scaffold:imports
)
`,
```

I don't have a Go toolchain available in the environment I drafted this in, so I hand-traced the AST byte offsets against this reproduction case and against the existing fixtures (multi-block imports, comments outside the import block, cgo blocks, etc.) to check for regressions, but please run CI/`go test ./...` before merging.

Closes #135